### PR TITLE
Semver For guardian/types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1304,8 +1304,8 @@
       "integrity": "sha512-qtLtLjXSa2HhUGv45BdqWLjsWy2Mdv0R5JSZaCVc2aNa+EEEQ3azQO9i1uPLcC29iQ55Ly0iiihTsZHv92U6oQ=="
     },
     "@guardian/types": {
-      "version": "github:guardian/types#9ec4c22c5b415122cabbb5c232836022fe3994d1",
-      "from": "github:guardian/types",
+      "version": "github:guardian/types#3277ac1456496a98115a7bb80bb79d385ed8417d",
+      "from": "github:guardian/types#semver:^0.4.3",
       "requires": {
         "typescript": "^3.8.3"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.28",
     "@guardian/src-foundations": "^2.0.0",
-    "@guardian/types": "github:guardian/types",
+    "@guardian/types": "github:guardian/types#semver:^0.4.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "typescript": "^3.9.7"


### PR DESCRIPTION
## Why?

Using semver to specify the `guardian/types` dependency, as suggested by @webb04 [here](https://github.com/guardian/image-rendering/pull/1#discussion_r466963235). For more details see the [similar PR](https://github.com/guardian/apps-rendering/pull/581) on Apps-Rendering.

FYI @guardian/client-side-infra 

## Changes

- Used semver to specify `guardian/types` dependency
- Bumped `guardian/types` to `0.4.3`
