### PR TITLE
Sizes API For Img Component

### DIFF
--- a/src/components/bodyImage.stories.tsx
+++ b/src/components/bodyImage.stories.tsx
@@ -1,25 +1,18 @@
 // ----- Imports ----- //
 
 import React, { FC } from 'react';
-import { none } from '@guardian/types/option';
-import { Design, Display, Pillar } from '@guardian/types/Format';
+import { none, some } from '@guardian/types/option';
+import { Display, Design, Pillar } from '@guardian/types/Format';
 
-import Img from './img';
 import { image } from 'fixtures/image';
-
-
-// ----- Setup ----- //
-
-const sizes = { mediaQueries: [], default: '40vw' };
+import BodyImage from './bodyImage';
 
 
 // ----- Stories ----- //
 
 const Default: FC = () =>
-    <Img
+    <BodyImage
         image={image}
-        sizes={sizes}
-        className={none}
         format={{
             design: Design.Article,
             display: Display.Standard,
@@ -27,18 +20,12 @@ const Default: FC = () =>
         }}
         supportsDarkMode={true}
         lightboxClassName={none}
+        caption={some('Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images')}
     />
 
-const Placeholder: FC = () =>
-    <Img
-        image={{
-            ...image,
-            src: '',
-            srcset: '',
-            dpr2Srcset: '',
-        }}
-        sizes={sizes}
-        className={none}
+const NoCaption: FC = () =>
+    <BodyImage
+        image={image}
         format={{
             design: Design.Article,
             display: Display.Standard,
@@ -46,17 +33,18 @@ const Placeholder: FC = () =>
         }}
         supportsDarkMode={true}
         lightboxClassName={none}
+        caption={none}
     />
 
 
 // ----- Exports ----- //
 
 export default {
-    component: Img,
-    title: 'Img',
+    component: BodyImage,
+    title: 'BodyImage',
 }
 
 export {
     Default,
-    Placeholder,
-};
+    NoCaption,
+}

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -1,0 +1,68 @@
+/** @jsx jsx */
+// ----- Imports ----- //
+
+import { FC, ReactNode } from 'react';
+import { remSpace } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { Option, none } from '@guardian/types/option';
+import { Format } from '@guardian/types/Format';
+import { css, jsx } from '@emotion/core';
+
+import { Image } from 'image';
+import Img from 'components/img';
+import FigCaption from 'components/figCaption';
+
+
+// ----- Setup ----- //
+
+const width = `calc(100vw - ${remSpace[4]})`;
+const phabletWidth = '620px';
+
+
+// ----- Component ----- //
+
+interface Props {
+    image: Image;
+    format: Format;
+    supportsDarkMode: boolean;
+    lightboxClassName: Option<string>;
+    caption: Option<ReactNode>;
+}
+
+const styles = css`
+    margin: ${remSpace[4]} 0;
+    width: ${width};
+
+    ${from.phablet} {
+        width: ${phabletWidth};
+    }
+`;
+
+const BodyImage: FC<Props> = ({
+    image,
+    format,
+    supportsDarkMode,
+    lightboxClassName,
+    caption,
+}) =>
+    <figure css={styles}>
+        <Img
+            image={image}
+            sizes={{
+                mediaQueries: [{ breakpoint: 'phablet', size: phabletWidth }],
+                default: width,
+            }}
+            className={none}
+            format={format}
+            supportsDarkMode={supportsDarkMode}
+            lightboxClassName={lightboxClassName}
+        />
+        <FigCaption format={format} supportsDarkMode={supportsDarkMode}>
+            {caption}
+        </FigCaption>
+    </figure>
+
+
+// ----- Exports ----- //
+
+export default BodyImage;

--- a/src/components/figCaption.stories.tsx
+++ b/src/components/figCaption.stories.tsx
@@ -1,0 +1,34 @@
+// ----- Imports ----- //
+
+import React, { FC } from 'react';
+import { Design, Display, Pillar } from '@guardian/types/Format';
+import { some } from '@guardian/types/option';
+
+import FigCaption from './figCaption';
+
+
+// ----- Stories ----- //
+
+const Default: FC = () =>
+    <FigCaption
+        format={{
+            design: Design.Article,
+            display: Display.Standard,
+            pillar: Pillar.News,
+        }}
+        supportsDarkMode={true}
+    >
+        {some('Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images')}
+    </FigCaption>
+
+
+// ----- Exports ----- //
+
+export default {
+    component: FigCaption,
+    title: 'FigCaption',
+}
+
+export {
+    Default,
+}

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -1,0 +1,97 @@
+/** @jsx jsx */
+// ----- Imports ----- //
+
+import { FC, ReactNode } from 'react';
+import { Format, Design } from '@guardian/types/Format';
+import { Option, OptionKind } from '@guardian/types/option';
+import { remSpace } from '@guardian/src-foundations';
+import { text, neutral } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { SerializedStyles, css, jsx } from '@emotion/core';
+
+import { darkModeCss } from 'lib';
+import { fill } from 'editorialPalette';
+
+
+// ----- Sub-Components ----- //
+
+interface TriangleProps {
+    format: Format;
+    supportsDarkMode: boolean;
+}
+
+const triangleStyles = (format: Format, supportsDarkMode: boolean): SerializedStyles => css`
+    fill: ${fill.iconPrimary(format)};
+    height: 0.8em;
+    padding-right: ${remSpace[1]};
+
+    ${darkModeCss(supportsDarkMode)`
+        fill: ${fill.iconPrimaryInverse(format)};
+    `}
+`;
+
+const Triangle: FC<TriangleProps> = ({ format, supportsDarkMode }) => {
+    switch (format.design) {
+        case Design.Media:
+            return null;
+        default:
+            return (
+                <svg
+                    css={triangleStyles(format, supportsDarkMode)}
+                    viewBox="0 0 10 9"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <polygon points="0,9 5,0 10,9" />
+                </svg>
+            );
+    }
+}
+
+
+// ----- Component ----- //
+
+interface Props {
+    format: Format;
+    supportsDarkMode: boolean;
+    children: Option<ReactNode>;
+}
+
+const styles = css`
+    ${textSans.xsmall()}
+    padding-top: ${remSpace[2]};
+    color: ${text.supporting};
+`;
+
+const mediaStyles = css`
+    color: ${neutral[86]};
+`;
+
+const getStyles = (format: Format): SerializedStyles => {
+    switch (format.design) {
+        case Design.Media:
+            return css(styles, mediaStyles);
+        default:
+            return styles;
+    }
+}
+
+const FigCaption: FC<Props> = ({ format, supportsDarkMode, children }) => {
+    switch (children.kind) {
+        case OptionKind.Some:
+            return (
+                <figcaption css={getStyles(format)}>
+                    <Triangle format={format} supportsDarkMode={supportsDarkMode} />
+                    {children.value}
+                </figcaption>
+            );
+
+        default:
+            return null;
+    }
+    
+}
+
+
+// ----- Exports ----- //
+
+export default FigCaption;

--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -1,7 +1,6 @@
 // ----- Imports ----- //
 
 import React, { FC } from 'react';
-import { css } from '@emotion/core';
 import { none, some } from '@guardian/types/option';
 import { Design, Display, Pillar } from '@guardian/types/Format';
 
@@ -24,7 +23,7 @@ const image: Image = {
     role: Role.Standard,
 };
 
-const sizes = '40vw';
+const sizes = { mediaQueries: [], default: '40vw' };
 
 
 // ----- Stories ----- //
@@ -52,11 +51,7 @@ const Placeholder: FC = () =>
             dpr2Srcset: '',
         }}
         sizes={sizes}
-        className={some(css`
-            width: ${sizes};
-            height: calc(${sizes} * ${image.height / image.width});
-            display: block;
-        `)}
+        className={none}
         format={{
             design: Design.Article,
             display: Display.Standard,

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -9,6 +9,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 
 import { Image, Role } from 'image';
 import { darkModeCss } from 'lib';
+import { Sizes, sizesAttribute, styles as sizeStyles } from 'sizes';
 
 
 // ----- Functions ----- //
@@ -40,39 +41,52 @@ const getLightboxClassName = (
 
 interface Props {
     image: Image;
-    sizes: string;
+    sizes: Sizes;
     className: Option<SerializedStyles>;
     format: Format;
     supportsDarkMode: boolean;
     lightboxClassName: Option<string>;
 }
 
-const styles = (
-    role: Role,
+const styles = (format: Format, supportsDarkMode: boolean): SerializedStyles => css`
+    background-color: ${backgroundColour(format)};
+    color: ${neutral[60]};
+    display: block;
+
+    ${darkModeCss(supportsDarkMode)`
+        background-color: ${neutral[20]};
+    `}
+`;
+
+const thumbnailStyles = css`
+    color: ${neutral[60]};
+`;
+
+const getStyles = (
+    image: Image,
     format: Format,
     supportsDarkMode: boolean,
+    sizes: Sizes,
 ): SerializedStyles => {
-    switch (role) {
+    const dimensions = sizeStyles(sizes, image.width, image.height);
+
+    switch (image.role) {
         case Role.Thumbnail:
-            return css`color: ${neutral[60]};`;
+            return css(dimensions, thumbnailStyles);
         default:
-            return css`
-                background-color: ${backgroundColour(format)};
-                color: ${neutral[60]};
-                ${darkModeCss(supportsDarkMode)`background-color: ${neutral[20]};`}
-            `;
+            return css(dimensions, styles(format, supportsDarkMode));
     }   
 }
 
 const Img: FC<Props> = ({ image, sizes, className, format, supportsDarkMode, lightboxClassName }) =>
     <picture>
         <source
-            sizes={sizes}
+            sizes={sizesAttribute(sizes)}
             srcSet={image.dpr2Srcset}
             media="(-webkit-min-device-pixel-ratio: 1.25), (min-resolution: 120dpi)"
         />
         <source
-            sizes={sizes}
+            sizes={sizesAttribute(sizes)}
             srcSet={image.srcset}
         />
         <img
@@ -80,7 +94,7 @@ const Img: FC<Props> = ({ image, sizes, className, format, supportsDarkMode, lig
             alt={withDefault('')(image.alt)}
             className={getLightboxClassName(image.width, lightboxClassName)}
             css={[
-                styles(image.role, format, supportsDarkMode),
+                getStyles(image, format, supportsDarkMode, sizes),
                 withDefault<SerializedStyles | undefined>(undefined)(className),
             ]}
             data-ratio={image.height / image.width}

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -1,0 +1,65 @@
+// ----- Imports ----- //
+
+import { Format, Pillar } from '@guardian/types/Format';
+import {
+    news,
+    opinion,
+    sport,
+    culture,
+    lifestyle,
+} from '@guardian/src-foundations/palette';
+
+
+// ----- Types ----- //
+
+type Colour = string;
+
+
+// ----- Functions ----- //
+
+const fillIconPrimary = (format: Format): Colour => {
+    switch (format.pillar) {
+        case Pillar.Opinion:
+            return opinion[400];
+        case Pillar.Sport:
+            return sport[400];
+        case Pillar.Culture:
+            return culture[400];
+        case Pillar.Lifestyle:
+            return lifestyle[400];
+        case Pillar.News:
+        default:
+            return news[400];
+    }
+}
+
+const fillIconPrimaryInverse = (format: Format): Colour => {
+    switch (format.pillar) {
+        case Pillar.Opinion:
+            return opinion[500];
+        case Pillar.Sport:
+            return sport[500];
+        case Pillar.Culture:
+            return culture[500];
+        case Pillar.Lifestyle:
+            return lifestyle[500];
+        case Pillar.News:
+        default:
+            return news[500];
+    }
+}
+
+
+// ----- API ----- //
+
+const fill = {
+    iconPrimary: fillIconPrimary,
+    iconPrimaryInverse: fillIconPrimaryInverse,
+};
+
+
+// ----- Exports ----- //
+
+export {
+    fill,
+}

--- a/src/fixtures/image.ts
+++ b/src/fixtures/image.ts
@@ -1,0 +1,28 @@
+// ----- Imports ----- //
+
+import { none, some } from '@guardian/types/option';
+
+import { Role, Image } from 'image';
+
+
+// ----- Fixtures ----- //
+
+const image: Image = {
+    src: 'https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=500&quality=85&fit=bounds&s=f1467e8be532692f4aaa9597adc07306',
+    srcset: 'https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=140&quality=85&fit=bounds&s=822845d0639c4b4deb572c7e6f72baea 140w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=500&quality=85&fit=bounds&s=f1467e8be532692f4aaa9597adc07306 500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1000&quality=85&fit=bounds&s=ccf2535722cc3f3034495dae0e761e0c 1000w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1500&quality=85&fit=bounds&s=7764655d28b562fbbcc184c3bd46e7b2 1500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=2000&quality=85&fit=bounds&s=78425cffd6524942947d5177a5713bdd 2000w',
+    dpr2Srcset: 'https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=140&quality=45&fit=bounds&s=ad06e480e9a2cbd3f59c77f6b1f06454 140w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=500&quality=45&fit=bounds&s=1fe31b8d41295aba16065512712d59c9 500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1000&quality=45&fit=bounds&s=35194881b5e1c282daf291a59cafba65 1000w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=1500&quality=45&fit=bounds&s=37a96bc69746a31f7cd982b21d63ef13 1500w, https://i.guim.co.uk/img/media/81af1958373e29e430bf4f894ae666feb5dad47f/0_188_5644_3387/master/5644.jpg?width=2000&quality=45&fit=bounds&s=07fa87119df669fb396b8f81732b7674 2000w',
+    alt: some('Demo image'),
+    width: 5644,
+    height: 3387,
+    caption: none,
+    credit: none,
+    rawCaptionHtml: none,
+    role: Role.Standard,
+};
+
+
+// ----- Exports ----- //
+
+export {
+    image,
+}


### PR DESCRIPTION
## Why?

Fixes #5. Makes use of the new sizes API to handle the `sizes` attribute and CSS dimensions (`width` and `height` at different breakpoints) of the `Img` component.

## Changes

- Used `sizesAttribute` for `<source>` sizes
- Used `styles` to build dimension (width and height) styles
- Updated `Img` stories to use new sizes API
- Updated `Img` stories to remove now-unnecessary CSS overrides
