### PR TITLE
JSX Factory In Tsconfig

### DIFF
--- a/src/components/bodyImage.stories.tsx
+++ b/src/components/bodyImage.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import React, { FC } from 'react';
+import { FC } from 'react';
+import { jsx } from '@emotion/core';
 import { none, some } from '@guardian/types/option';
 import { Display, Design, Pillar } from '@guardian/types/Format';
 

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 // ----- Imports ----- //
 
 import { FC, ReactNode } from 'react';

--- a/src/components/figCaption.stories.tsx
+++ b/src/components/figCaption.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import React, { FC } from 'react';
+import { FC } from 'react';
+import { jsx } from '@emotion/core';
 import { Design, Display, Pillar } from '@guardian/types/Format';
 import { some } from '@guardian/types/option';
 

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 // ----- Imports ----- //
 
 import { FC, ReactNode } from 'react';

--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import React, { FC } from 'react';
+import { FC } from 'react';
+import { jsx } from '@emotion/core';
 import { none } from '@guardian/types/option';
 import { Design, Display, Pillar } from '@guardian/types/Format';
 

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 // ----- Imports ----- //
 
 import { FC } from 'react';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "esModuleInterop": true,
         // Transpile jsx
         "jsx": "react",
+        "jsxFactory": "jsx",
         "noUnusedLocals": true,
         "noUnusedParameters": false,
         "baseUrl": "src/",


### PR DESCRIPTION
## Why?

JSX is not valid JavaScript - it gets converted to a "factory function" by whatever compiler/transpiler your project uses (TypeScript, Babel etc.). 

When using React, the standard factory function is `React.createElement`. However, to make use of the Emotion `css` prop, Emotion provides an alternative factory function that it exports as `jsx`. This can be specified as a "JSX Pragma" comment, as described [here](https://emotion.sh/docs/css-prop#jsx-pragma) in the Emotion docs, which is what we've been using so far.

Adding this pragma comment at the top of every file is a bit messy. It turns out that TypeScript instead allows you to [configure this factory function](https://www.typescriptlang.org/docs/handbook/jsx.html#factory-functions) at the project level in `tsconfig.json`.

This PR switches to the `tsconfig.json` method, and removes the pragma comments.

## Changes

- Allows use of the Emotion `css` prop
- No longer uses the per-file pragma comment
- Import `jsx` from Emotion where needed
