### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,32 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Cache Dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: node-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: node-
+    - run: npm ci
+    - run: npm run build
+    - run: npm test

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest",
+    "test": "jest --updateSnapshot",
     "test:watch": "jest --watch",
     "storybook": "start-storybook -p 8181 --ci"
   },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "jest --updateSnapshot",
+    "test": "jest",
     "test:watch": "jest --watch",
     "storybook": "start-storybook -p 8181 --ci"
   },
@@ -46,6 +46,7 @@
     "transformIgnorePatterns": [
       "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
     ],
-    "snapshotSerializers": ["jest-emotion"]
+    "snapshotSerializers": ["jest-emotion"],
+    "testPathIgnorePatterns": ["dist"]
   }
 }


### PR DESCRIPTION
## Why?

To run validation checks against PRs and `main` branch merges. This workflow checks out the code, installs npm dependencies (with cache), and runs the `build`/`test` scripts. Based on GitHub's default Node.js workflow, and [the one](https://github.com/guardian/apps-rendering/blob/15773fa4d030f6d4b091b35bd5a5295414b3cb40/.github/workflows/nodejs.yml) currently used by apps-rendering.

**Note:** I've included runs for both Node v10 and Node v12, because DCR is on 10 and AR is on 12.

## Changes

- New Node-based GH workflow to validate changes
