### PR TITLE
Refactor Lightbox

### DIFF
--- a/src/components/bodyImage.stories.tsx
+++ b/src/components/bodyImage.stories.tsx
@@ -4,7 +4,7 @@ import React, { FC } from 'react';
 import { none, some } from '@guardian/types/option';
 import { Display, Design, Pillar } from '@guardian/types/Format';
 
-import { image } from 'fixtures/image';
+import { image } from '../fixtures/image';
 import BodyImage from './bodyImage';
 
 
@@ -19,7 +19,7 @@ const Default: FC = () =>
             pillar: Pillar.News,
         }}
         supportsDarkMode={true}
-        lightboxClassName={none}
+        lightbox={none}
         caption={some('Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images')}
     />
 
@@ -32,7 +32,7 @@ const NoCaption: FC = () =>
             pillar: Pillar.News,
         }}
         supportsDarkMode={true}
-        lightboxClassName={none}
+        lightbox={none}
         caption={none}
     />
 

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -7,9 +7,10 @@ import { Option, none } from '@guardian/types/option';
 import { Format } from '@guardian/types/Format';
 import { css } from '@emotion/core';
 
-import { Image } from 'image';
-import Img from 'components/img';
-import FigCaption from 'components/figCaption';
+import { Image } from '../image';
+import type { Lightbox } from '../lightbox';
+import Img from './img';
+import FigCaption from './figCaption';
 
 
 // ----- Setup ----- //
@@ -24,7 +25,7 @@ interface Props {
     image: Image;
     format: Format;
     supportsDarkMode: boolean;
-    lightboxClassName: Option<string>;
+    lightbox: Option<Lightbox>;
     caption: Option<ReactNode>;
 }
 
@@ -41,7 +42,7 @@ const BodyImage: FC<Props> = ({
     image,
     format,
     supportsDarkMode,
-    lightboxClassName,
+    lightbox,
     caption,
 }) =>
     <figure css={styles}>
@@ -54,7 +55,7 @@ const BodyImage: FC<Props> = ({
             className={none}
             format={format}
             supportsDarkMode={supportsDarkMode}
-            lightboxClassName={lightboxClassName}
+            lightbox={lightbox}
         />
         <FigCaption format={format} supportsDarkMode={supportsDarkMode}>
             {caption}

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -8,8 +8,8 @@ import { text, neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { SerializedStyles, css } from '@emotion/core';
 
-import { darkModeCss } from 'lib';
-import { fill } from 'editorialPalette';
+import { darkModeCss } from '../lib';
+import { fill } from '../editorialPalette';
 
 
 // ----- Sub-Components ----- //

--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -5,7 +5,7 @@ import { none } from '@guardian/types/option';
 import { Design, Display, Pillar } from '@guardian/types/Format';
 
 import Img from './img';
-import { image } from 'fixtures/image';
+import { image } from '../fixtures/image';
 
 
 // ----- Setup ----- //
@@ -26,7 +26,7 @@ const Default: FC = () =>
             pillar: Pillar.News,
         }}
         supportsDarkMode={true}
-        lightboxClassName={none}
+        lightbox={none}
     />
 
 const Placeholder: FC = () =>
@@ -45,7 +45,7 @@ const Placeholder: FC = () =>
             pillar: Pillar.News,
         }}
         supportsDarkMode={true}
-        lightboxClassName={none}
+        lightbox={none}
     />
 
 

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -2,13 +2,14 @@
 
 import React, { FC } from 'react';
 import { SerializedStyles, css } from '@emotion/core';
-import { Option, OptionKind, withDefault } from '@guardian/types/option';
+import { Option, withDefault } from '@guardian/types/option';
 import { Format, Design } from '@guardian/types/Format';
 import { neutral } from '@guardian/src-foundations/palette';
 
-import { Image, Role } from 'image';
-import { darkModeCss } from 'lib';
-import { Sizes, sizesAttribute, styles as sizeStyles } from 'sizes';
+import { Image, Role } from '../image';
+import { darkModeCss } from '../lib';
+import { Sizes, sizesAttribute, styles as sizeStyles } from '../sizes';
+import { Lightbox, getClassName, getCaption, getCredit } from '../lightbox';
 
 
 // ----- Functions ----- //
@@ -24,17 +25,6 @@ const backgroundColour = (format: Format): string => {
     }
 };
 
-const getLightboxClassName = (
-    imageWidth: number,
-    className: Option<string>,
-): string | undefined => {
-    if (imageWidth > 620 && className.kind === OptionKind.Some) {
-        return className.value;
-    }
-
-    return undefined;
-}
-
 
 // ----- Component ----- //
 
@@ -44,7 +34,7 @@ interface Props {
     className: Option<SerializedStyles>;
     format: Format;
     supportsDarkMode: boolean;
-    lightboxClassName: Option<string>;
+    lightbox: Option<Lightbox>;
 }
 
 const styles = (format: Format, supportsDarkMode: boolean): SerializedStyles => css`
@@ -77,7 +67,14 @@ const getStyles = (
     }   
 }
 
-const Img: FC<Props> = ({ image, sizes, className, format, supportsDarkMode, lightboxClassName }) =>
+const Img: FC<Props> = ({
+    image,
+    sizes,
+    className,
+    format,
+    supportsDarkMode,
+    lightbox,
+}) =>
     <picture>
         <source
             sizes={sizesAttribute(sizes)}
@@ -91,14 +88,14 @@ const Img: FC<Props> = ({ image, sizes, className, format, supportsDarkMode, lig
         <img
             src={image.src}
             alt={withDefault('')(image.alt)}
-            className={getLightboxClassName(image.width, lightboxClassName)}
+            className={getClassName(image.width, lightbox)}
             css={[
                 getStyles(image, format, supportsDarkMode, sizes),
                 withDefault<SerializedStyles | undefined>(undefined)(className),
             ]}
             data-ratio={image.height / image.width}
-            data-caption={withDefault<string | undefined>(undefined)(image.rawCaptionHtml)}
-            data-credit={withDefault<string | undefined>(undefined)(image.credit)}
+            data-caption={getCaption(lightbox)}
+            data-credit={getCredit(lightbox)}
         />
     </picture>
 

--- a/src/fixtures/image.ts
+++ b/src/fixtures/image.ts
@@ -1,6 +1,6 @@
 // ----- Imports ----- //
 
-import { none, some } from '@guardian/types/option';
+import { some } from '@guardian/types/option';
 
 import { Role, Image } from 'image';
 
@@ -14,9 +14,6 @@ const image: Image = {
     alt: some('Demo image'),
     width: 5644,
     height: 3387,
-    caption: none,
-    credit: none,
-    rawCaptionHtml: none,
     role: Role.Standard,
 };
 

--- a/src/image.ts
+++ b/src/image.ts
@@ -18,9 +18,6 @@ interface Image {
     alt: Option<string>;
     width: number;
     height: number;
-    caption: Option<DocumentFragment>;
-    credit: Option<string>;
-    rawCaptionHtml: Option<string>;
     role: Role;
 }
 

--- a/src/lightbox.ts
+++ b/src/lightbox.ts
@@ -1,0 +1,65 @@
+// ----- Imports ----- //
+
+import { Option, OptionKind } from '@guardian/types/option';
+
+
+// ----- Types ----- //
+
+interface Lightbox {
+    className: string;
+    caption: Option<string>;
+    credit: Option<string>;
+}
+
+
+// ----- Functions ----- //
+
+/**
+ * Lightbox is only available for images above a certain size,
+ * we don't enable it for small images (e.g. thumbnails). Therefore
+ * this will only return a lightbox className if one is provided *and*
+ * the image is above a certain width.
+ */
+const getClassName = (
+    imageWidth: number,
+    lightbox: Option<Lightbox>,
+): string | undefined => {
+    if (imageWidth > 620 && lightbox.kind === OptionKind.Some) {
+        return lightbox.value.className;
+    }
+
+    return undefined;
+}
+
+const getCaption = (lightbox: Option<Lightbox>): string | undefined => {
+    if (
+        lightbox.kind === OptionKind.Some &&
+        lightbox.value.caption.kind === OptionKind.Some
+    ) {
+        return lightbox.value.caption.value;
+    }
+
+    return undefined;
+}
+
+const getCredit = (lightbox: Option<Lightbox>): string | undefined => {
+    if (
+        lightbox.kind === OptionKind.Some &&
+        lightbox.value.credit.kind === OptionKind.Some
+    ) {
+        return lightbox.value.credit.value;
+    }
+
+    return undefined;
+}
+
+
+// ----- Exports ----- //
+
+export type { Lightbox }
+
+export {
+    getClassName,
+    getCaption,
+    getCredit,
+}


### PR DESCRIPTION
## Why?

Previously we had `caption`, `credit` and `rawCaptionHtml` living directly on the `Image` type, and `rawCaptionHtml` as an `Option<DocumentFragment>`. This was too closely tied to the requirements that Apps-Rendering has for `Image`, which isn't relevant for this standalone repo. In `image-rendering` these fields are *only* present to provide `data` attributes for a possible lightbox implementation.

This PR explicitly makes these fields part of the lightbox API, and removes all references to `DocumentFragment` (an implementation detail of AR). This API may change again depending on DCR's requirements for the lightbox, but for now it works for AR, hopefully without being too prescriptive for other consumers.

**Note:** I've also switched to using relative paths because the absolute ones only work when the `tsconfig` for this project is available (which it isn't when the project is imported elsewhere).

## Changes

- New `lightbox` module
- Remove captions and credit from `Image`
- Make paths relative
