### PR TITLE
Thumbnail Images

### DIFF
--- a/src/components/bodyImage.stories.tsx
+++ b/src/components/bodyImage.stories.tsx
@@ -6,6 +6,23 @@ import { Display, Design, Pillar } from '@guardian/types/Format';
 
 import { image } from '../fixtures/image';
 import BodyImage from './bodyImage';
+import { Role } from '../image';
+
+
+// ----- Setup ----- //
+
+const format = {
+    design: Design.Article,
+    display: Display.Standard,
+    pillar: Pillar.News,
+};
+const caption = some('Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images');
+const copy = (
+    <>
+        <p>Ever since Mexico City was founded on an island in the lake of Texcoco its inhabitants have dreamed of water: containing it, draining it and now retaining it.</p>
+        <p>Nezahualcoyotl, the illustrious lord of Texcoco, made his name constructing a dyke shielding Mexico City’s Aztec predecessor city of Tenochtitlan from flooding. The gravest threat to Mexico City’s existence came from a five-year flood starting in 1629, almost causing the city to be abandoned. Ironically now its surrounding lake system has been drained, the greatest threat to the city’s existence is probably the rapid decline of its overstressed aquifers.</p>
+    </>
+);
 
 
 // ----- Stories ----- //
@@ -13,28 +30,50 @@ import BodyImage from './bodyImage';
 const Default: FC = () =>
     <BodyImage
         image={image}
-        format={{
-            design: Design.Article,
-            display: Display.Standard,
-            pillar: Pillar.News,
-        }}
+        format={format}
         supportsDarkMode={true}
         lightbox={none}
-        caption={some('Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images')}
+        caption={caption}
     />
 
 const NoCaption: FC = () =>
     <BodyImage
         image={image}
-        format={{
-            design: Design.Article,
-            display: Display.Standard,
-            pillar: Pillar.News,
-        }}
+        format={format}
         supportsDarkMode={true}
         lightbox={none}
         caption={none}
     />
+
+const Thumbnail: FC = () =>
+    <>
+        <BodyImage
+            image={{
+                ...image,
+                role: Role.Thumbnail,
+            }}
+            format={format}
+            supportsDarkMode={true}
+            lightbox={none}
+            caption={caption}
+        />
+        {copy}
+    </>
+
+const ThumbnailNoCaption: FC = () =>
+    <>
+        <BodyImage
+            image={{
+                ...image,
+                role: Role.Thumbnail,
+            }}
+            format={format}
+            supportsDarkMode={true}
+            lightbox={none}
+            caption={none}
+        />
+        {copy}
+    </>
 
 
 // ----- Exports ----- //
@@ -47,4 +86,6 @@ export default {
 export {
     Default,
     NoCaption,
+    Thumbnail,
+    ThumbnailNoCaption,
 }

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -5,18 +5,38 @@ import { remSpace } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Option, none } from '@guardian/types/option';
 import { Format } from '@guardian/types/Format';
-import { css } from '@emotion/core';
+import { css, SerializedStyles } from '@emotion/core';
 
-import { Image } from '../image';
+import { Image, Role } from '../image';
 import type { Lightbox } from '../lightbox';
 import Img from './img';
 import FigCaption from './figCaption';
+import { Sizes } from '../sizes';
 
 
 // ----- Setup ----- //
 
 const width = `calc(100vw - ${remSpace[4]})`;
 const phabletWidth = '620px';
+const thumbnailWidth = '8.75rem';
+
+
+// ----- Functions ----- //
+
+const getSizes = (role: Role): Sizes => {
+    switch (role) {
+        case Role.Thumbnail:
+            return {
+                mediaQueries: [],
+                default: thumbnailWidth,
+            };
+        default:
+            return {
+                mediaQueries: [{ breakpoint: 'phablet', size: phabletWidth }],
+                default: width,
+            };
+    }
+}
 
 
 // ----- Component ----- //
@@ -38,6 +58,21 @@ const styles = css`
     }
 `;
 
+const thumbnailStyles = css`
+    float: left;
+    width: ${thumbnailWidth};
+    margin: 0 ${remSpace[3]} 0 0;
+`;
+
+const getStyles = (role: Role): SerializedStyles => {
+    switch (role) {
+        case Role.Thumbnail:
+            return thumbnailStyles;
+        default:
+            return styles;
+    }
+}
+
 const BodyImage: FC<Props> = ({
     image,
     format,
@@ -45,13 +80,10 @@ const BodyImage: FC<Props> = ({
     lightbox,
     caption,
 }) =>
-    <figure css={styles}>
+    <figure css={getStyles(image.role)}>
         <Img
             image={image}
-            sizes={{
-                mediaQueries: [{ breakpoint: 'phablet', size: phabletWidth }],
-                default: width,
-            }}
+            sizes={getSizes(image.role)}
             className={none}
             format={format}
             supportsDarkMode={supportsDarkMode}

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -6,7 +6,7 @@ import { Option, withDefault } from '@guardian/types/option';
 import { Format, Design } from '@guardian/types/Format';
 import { neutral } from '@guardian/src-foundations/palette';
 
-import { Image, Role } from '../image';
+import { Image } from '../image';
 import { darkModeCss } from '../lib';
 import { Sizes, sizesAttribute, styles as sizeStyles } from '../sizes';
 import { Lightbox, getClassName, getCaption, getCredit } from '../lightbox';
@@ -47,26 +47,6 @@ const styles = (format: Format, supportsDarkMode: boolean): SerializedStyles => 
     `}
 `;
 
-const thumbnailStyles = css`
-    color: ${neutral[60]};
-`;
-
-const getStyles = (
-    image: Image,
-    format: Format,
-    supportsDarkMode: boolean,
-    sizes: Sizes,
-): SerializedStyles => {
-    const dimensions = sizeStyles(sizes, image.width, image.height);
-
-    switch (image.role) {
-        case Role.Thumbnail:
-            return css(dimensions, thumbnailStyles);
-        default:
-            return css(dimensions, styles(format, supportsDarkMode));
-    }   
-}
-
 const Img: FC<Props> = ({
     image,
     sizes,
@@ -90,7 +70,8 @@ const Img: FC<Props> = ({
             alt={withDefault('')(image.alt)}
             className={getClassName(image.width, lightbox)}
             css={[
-                getStyles(image, format, supportsDarkMode, sizes),
+                sizeStyles(sizes, image.width, image.height),
+                styles(format, supportsDarkMode),
                 withDefault<SerializedStyles | undefined>(undefined)(className),
             ]}
             data-ratio={image.height / image.width}


### PR DESCRIPTION
## Why?

Adds support for images with a `Role` of `thumbnail`.

## Changes

- Removed knowledge of `Role` from `Img` component
- Choose `sizes` and `styles` based on `Role` in `BodyImage`
- Added stories for `BodyImage`s with thumbnail `Role`

## Screenshots

| Thumbnail | With Caption |
| - | - |
| ![thumbnail](https://user-images.githubusercontent.com/53781962/92954957-3dd8ac00-f45c-11ea-912e-fbe9efeb6ae4.png) | ![thumbnail-caption](https://user-images.githubusercontent.com/53781962/92954939-3addbb80-f45c-11ea-8ce0-0f838624eb67.png) |
