### PR TITLE
Add @guardian Namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "image-rendering",
+  "name": "@guardian/image-rendering",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "image-rendering",
+  "name": "@guardian/image-rendering",
   "version": "0.1.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "index.ts",


### PR DESCRIPTION
## Why?

Adds the `@guardian` prefix to the project name to avoid clash with other projects.

## Changes

- Add `@guardian` prefix to name in `package.json` and `package-lock.json`
