### PR TITLE
Left Column Thumbnail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "index.ts",
   "dependencies": {

--- a/src/components/bodyImage.stories.tsx
+++ b/src/components/bodyImage.stories.tsx
@@ -34,6 +34,7 @@ const Default: FC = () =>
         supportsDarkMode={true}
         lightbox={none}
         caption={caption}
+        leftColumnBreakpoint={none}
     />
 
 const NoCaption: FC = () =>
@@ -43,6 +44,7 @@ const NoCaption: FC = () =>
         supportsDarkMode={true}
         lightbox={none}
         caption={none}
+        leftColumnBreakpoint={none}
     />
 
 const Thumbnail: FC = () =>
@@ -56,6 +58,7 @@ const Thumbnail: FC = () =>
             supportsDarkMode={true}
             lightbox={none}
             caption={caption}
+            leftColumnBreakpoint={none}
         />
         {copy}
     </>
@@ -71,6 +74,7 @@ const ThumbnailNoCaption: FC = () =>
             supportsDarkMode={true}
             lightbox={none}
             caption={none}
+            leftColumnBreakpoint={none}
         />
         {copy}
     </>

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -12,6 +12,7 @@ import type { Lightbox } from '../lightbox';
 import Img from './img';
 import FigCaption from './figCaption';
 import { Sizes } from '../sizes';
+import { darkModeCss } from 'lib';
 
 
 // ----- Setup ----- //
@@ -70,10 +71,16 @@ const thumbnailStyles = (leftColumnBreakpoint: Breakpoint): SerializedStyles => 
     }
 `;
 
-const imgStyles = (role: Role): Option<SerializedStyles> => {
+const imgStyles = (role: Role, supportsDarkMode: boolean): Option<SerializedStyles> => {
     switch (role) {
         case Role.Thumbnail:
-            return some(css`border-radius: 100%;`);
+            return some(css`
+                background-color: transparent;
+
+                ${darkModeCss(supportsDarkMode)`
+                    background-color: transparent;
+                `}
+            `);
         default:
             return none;
     }
@@ -100,7 +107,7 @@ const BodyImage: FC<Props> = ({
         <Img
             image={image}
             sizes={getSizes(image.role)}
-            className={imgStyles(image.role)}
+            className={imgStyles(image.role, supportsDarkMode)}
             format={format}
             supportsDarkMode={supportsDarkMode}
             lightbox={lightbox}

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -12,7 +12,7 @@ import type { Lightbox } from '../lightbox';
 import Img from './img';
 import FigCaption from './figCaption';
 import { Sizes } from '../sizes';
-import { darkModeCss } from 'lib';
+import { darkModeCss } from '../lib';
 
 
 // ----- Setup ----- //

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -3,7 +3,7 @@
 import React, { FC, ReactNode } from 'react';
 import { remSpace } from '@guardian/src-foundations';
 import { Breakpoint, from } from '@guardian/src-foundations/mq';
-import { Option, none, withDefault } from '@guardian/types/option';
+import { Option, none, withDefault, some } from '@guardian/types/option';
 import { Format } from '@guardian/types/Format';
 import { css, SerializedStyles } from '@emotion/core';
 
@@ -59,17 +59,25 @@ const styles = css`
     }
 `;
 
-const thumbnailStyles = (leftColumnBreakpoint: Breakpoint) => css`
+const thumbnailStyles = (leftColumnBreakpoint: Breakpoint): SerializedStyles => css`
     float: left;
     width: ${thumbnailWidth};
     margin: 0 ${remSpace[3]} 0 0;
-    border-radius: 100%;
 
     ${from[leftColumnBreakpoint]} {
         position: absolute;
         transform: translateX(calc(-100% - ${remSpace[4]}));
     }
 `;
+
+const imgStyles = (role: Role): Option<SerializedStyles> => {
+    switch (role) {
+        case Role.Thumbnail:
+            return some(css`border-radius: 100%;`);
+        default:
+            return none;
+    }
+}
 
 const getStyles = (role: Role, leftColumnBreakpoint: Option<Breakpoint>): SerializedStyles => {
     switch (role) {
@@ -92,7 +100,7 @@ const BodyImage: FC<Props> = ({
         <Img
             image={image}
             sizes={getSizes(image.role)}
-            className={none}
+            className={imgStyles(image.role)}
             format={format}
             supportsDarkMode={supportsDarkMode}
             lightbox={lightbox}

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -2,8 +2,8 @@
 
 import React, { FC, ReactNode } from 'react';
 import { remSpace } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
-import { Option, none } from '@guardian/types/option';
+import { Breakpoint, from } from '@guardian/src-foundations/mq';
+import { Option, none, withDefault } from '@guardian/types/option';
 import { Format } from '@guardian/types/Format';
 import { css, SerializedStyles } from '@emotion/core';
 
@@ -47,6 +47,7 @@ interface Props {
     supportsDarkMode: boolean;
     lightbox: Option<Lightbox>;
     caption: Option<ReactNode>;
+    leftColumnBreakpoint: Option<Breakpoint>;
 }
 
 const styles = css`
@@ -58,16 +59,22 @@ const styles = css`
     }
 `;
 
-const thumbnailStyles = css`
+const thumbnailStyles = (leftColumnBreakpoint: Breakpoint) => css`
     float: left;
     width: ${thumbnailWidth};
     margin: 0 ${remSpace[3]} 0 0;
+    border-radius: 100%;
+
+    ${from[leftColumnBreakpoint]} {
+        position: absolute;
+        transform: translateX(calc(-100% - ${remSpace[4]}));
+    }
 `;
 
-const getStyles = (role: Role): SerializedStyles => {
+const getStyles = (role: Role, leftColumnBreakpoint: Option<Breakpoint>): SerializedStyles => {
     switch (role) {
         case Role.Thumbnail:
-            return thumbnailStyles;
+            return thumbnailStyles(withDefault<Breakpoint>('leftCol')(leftColumnBreakpoint));
         default:
             return styles;
     }
@@ -79,8 +86,9 @@ const BodyImage: FC<Props> = ({
     supportsDarkMode,
     lightbox,
     caption,
+    leftColumnBreakpoint,
 }) =>
-    <figure css={getStyles(image.role)}>
+    <figure css={getStyles(image.role, leftColumnBreakpoint)}>
         <Img
             image={image}
             sizes={getSizes(image.role)}


### PR DESCRIPTION
## Why?

Adds support for thumbnails being pulled out of the body of content into the left column above certain breakpoints.

**Note:** Because Apps does this at the `wide` breakpoint, unlike Dotcom which does this at the `leftCol` breakpoint, I've had to add an extra prop to specify the breakpoint from which to do this. It defaults to `leftCol`, so dotcom should just be able to pass `none` and move on. Hopefully one day Apps will be brought into alignment with the dotcom styles at wider breakpoints and we can get rid of this additional prop.

## Changes

- Above a certain breakpoint translate the thumbnail image to the left
- Added extra prop to set a custom breakpoint for this
- Make thumbnail placeholder a circle
- Set version to 1.0.0 (I think this is ready for AR to use!)

## Screenshots

*On Apps-Rendering*

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/53781962/96446513-4ebdcf80-1209-11eb-87a6-900798ffa53a.png) | ![after](https://user-images.githubusercontent.com/53781962/96446496-4d8ca280-1209-11eb-876e-89611209867e.png) |
