### PR TITLE
Index File

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@guardian/image-rendering",
   "version": "1.0.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
-  "main": "index.ts",
+  "main": "src/index.ts",
   "dependencies": {
     "@emotion/babel-preset-css-prop": "^10.0.27",
     "@emotion/core": "^10.0.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "src/index.ts",
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,13 @@
+// ----- Types ----- //
+
+export type { Image } from './image';
+export { Role } from './image';
+export type { Lightbox } from './lightbox';
+export type { Sizes } from './sizes';
+
+
+// ----- Components ----- //
+
+export { default as BodyImage } from './components/bodyImage';
+export { default as FigCaption } from './components/figCaption';
+export { default as Img } from './components/img';


### PR DESCRIPTION
## Why?

Provides a nicer import experience for consumers. For example:

```ts
import BodyImage from '@guardian/image-rendering/src/components/bodyImage';
import { Role } from '@guardian/image-rendering/src/image';
```

becomes:

```ts
import { BodyImage } from '@guardian/image-rendering';
import { Role } from '@guardian/image-rendering';
```

## Changes

- Added `index.ts` file with exports
- Bumped to version 1.1.0
