### PR TITLE
BodyImage Width 100%

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -17,7 +17,7 @@ import { darkModeCss } from '../lib';
 
 // ----- Setup ----- //
 
-const width = `calc(100vw - ${remSpace[4]})`;
+const width = '100%';
 const phabletWidth = '620px';
 const thumbnailWidth = '8.75rem';
 


### PR DESCRIPTION
## Why?

Using `vw` in conjunction with scrollbars seems to cause scrollbar overlap in some browsers (Chrome and Safari). The original issue was noted by @webb04 [in an apps-rendering PR](https://github.com/guardian/apps-rendering/pull/844#pullrequestreview-514618226).

## Changes

- Gave `BodyImage` `width: 100%;` on narrow breakpoints

## Screenshots

Example from Apps-Rendering in Chrome:

| Before | After |
| - | - |
| ![before](https://user-images.githubusercontent.com/53781962/96907268-ed109600-1492-11eb-9f58-0e5c390c4d35.jpg) | ![after](https://user-images.githubusercontent.com/53781962/96907274-ee41c300-1492-11eb-9cfd-f81a179a2ae2.jpg) |
