### PR TITLE
only run preinstall locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^16.9.54",
     "@types/react-test-renderer": "^16.9.3",
     "babel-loader": "^8.1.0",
+    "is-ci": "^2.0.0",
     "jest": "^26.6.0",
     "jest-emotion": "^10.0.32",
     "react-test-renderer": "^16.14.0",
@@ -30,7 +31,7 @@
     "ts-loader": "^8.0.7"
   },
   "scripts": {
-    "preinstall": "if [[ $npm_execpath =~ 'yarn' ]]; then echo 'Use NPM!' && exit 1; fi",
+    "preinstall": "is-ci || if [[ $npm_execpath =~ 'yarn' ]]; then echo 'Use NPM!' && exit 1; fi",
     "build": "npm run build:tsc && npm run build:babel && npm run build:cleanup",
     "build:tsc": "tsc --outDir tmp",
     "build:babel": "babel tmp --config-file ./config/babel.config.json --out-dir dist --copy-files",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {
@@ -23,7 +23,6 @@
     "@types/react": "^16.9.54",
     "@types/react-test-renderer": "^16.9.3",
     "babel-loader": "^8.1.0",
-    "is-ci": "^2.0.0",
     "jest": "^26.6.0",
     "jest-emotion": "^10.0.32",
     "react-test-renderer": "^16.14.0",
@@ -31,7 +30,7 @@
     "ts-loader": "^8.0.7"
   },
   "scripts": {
-    "preinstall": "is-ci || if [[ $npm_execpath =~ 'yarn' ]]; then echo 'Use NPM!' && exit 1; fi",
+    "preinstall": "[ -z \"$CI\" ] || if [[ $npm_execpath =~ 'yarn' ]]; then echo 'Use NPM!' && exit 1; fi",
     "build": "npm run build:tsc && npm run build:babel && npm run build:cleanup",
     "build:tsc": "tsc --outDir tmp",
     "build:babel": "babel tmp --config-file ./config/babel.config.json --out-dir dist --copy-files",


### PR DESCRIPTION
Seeing failures on some Teamcity instances for apps-rendering related to the `image-rendering` package.

<img width="190" alt="Screen Shot 2020-11-03 at 17 35 14" src="https://user-images.githubusercontent.com/11618797/98025941-461cea00-1e02-11eb-8c30-4e0681177bd5.png">

Also adding `is-ci` as a package wouldn't work because the script was `preinstall`