### PR TITLE
Bump Package Version To 3.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.2",
+  "version": "3.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.2",
+  "version": "3.0.4",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
## Why?

Some internal dependency updates, so bumping the patch version. I released these in `v3.0.3` but forgot update the package version, so I'm re-releasing as `v3.0.4`.

## Changes

- Updated `package.json` and `package-lock.json` to version `3.0.4`
