### PR TITLE
Bump To v3.0.5 To Capture Dependency Updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
## Why?

Dependency updates in #116, #117 and #120.

## Changes

- Bumped `version` in `package.json` and `package-lock.json`.
