### PR TITLE
Bump Version To v4.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.5",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "3.0.5",
+  "version": "4.0.1",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
## Why?

Bumping version to `v4.0.1` to cover changes in #131.

**Note:** I accidentally released `v4.0.0` without doing this, hence why it's now `4.0.1`.

## Changes

- Version `4.0.1` in `package.json` and `package-lock.json`
