### PR TITLE
Raised Chromatic Diff Threshold For Img Story

### DIFF
--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -55,7 +55,7 @@ export default {
   component: Img,
   title: "Img",
   parameters: {
-    chromatic: { diffThreshold: 0.2 }
+    chromatic: { diffThreshold: 0.2 },
   },
 };
 

--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -54,6 +54,9 @@ const Placeholder: FC = () => (
 export default {
   component: Img,
   title: "Img",
+  parameters: {
+    chromatic: { diffThreshold: 0.2 }
+  },
 };
 
 export { Default, Placeholder };


### PR DESCRIPTION
## Why?

Chromatic's visual diff is repeatedly reporting changes to the `Img` component. However this difference is actually down to small changes in how images are rendered between screenshots, as seen here:

![chromatic-diff](https://user-images.githubusercontent.com/53781962/101193671-d6925880-3654-11eb-9b46-7233b5c9e7c3.jpg)

It's possible to reduce the sensitivity of this visual diff using the [`diffThreshold` parameter](https://www.chromatic.com/docs/threshold) (thanks to @oliverlloyd for sharing this!), which is what this PR does.

## Changes

- Updated the `diffThreshold` for the `Img` stories to make the visual diff less sensitive
