### PR TITLE
Tweak Screenshot Diff Threshold

### DIFF
--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -55,7 +55,7 @@ export default {
   component: Img,
   title: "Img",
   parameters: {
-    chromatic: { diffThreshold: 0.2 },
+    chromatic: { diffThreshold: 0.25 },
   },
 };
 


### PR DESCRIPTION
## Why?

We're still getting a few false positives on the visual diffs for `Img` stories. This lowers the accuracy slightly in an attempt to avoid that. Follow-on from #137.

## Changes

- Raised threshold for `Img` stories from `0.2` to `0.25`
