### PR TITLE
Bump To v4.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
## Why?

There have been a number of dependency updates since `v4.0.1`, view the full changes here: https://github.com/guardian/image-rendering/compare/v4.0.1...f67a71f.

## Changes

- Bumped version to `v4.0.2`
