### PR TITLE
Srcsets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,12 @@ export type { Image } from "./image";
 export { Role } from "./image";
 export type { Lightbox } from "./lightbox";
 export type { Sizes } from "./sizes";
+export type { Srcsets } from "./srcsets";
+export { Dpr } from "./srcsets";
+
+// ----- Functions ----- //
+
+export { src, srcset, srcsets, srcsetWithWidths } from "./srcsets";
 
 // ----- Components ----- //
 

--- a/src/srcsets.test.ts
+++ b/src/srcsets.test.ts
@@ -1,0 +1,25 @@
+// ----- Imports ----- //
+
+import { Dpr, srcset } from "./srcsets";
+
+// ----- Tests ----- //
+
+describe("srcsets", () => {
+  test("show lower quality when DPR is 2", () => {
+    const src = srcset(
+      "https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg",
+      "",
+      Dpr.Two
+    );
+    expect(src).toContain("quality=45");
+  });
+
+  test("show higher quality when DPR is 1", () => {
+    const src = srcset(
+      "https://media.guim.co.uk/img/media/948ad0a2ebe6d931d8827ea89ac184986af76c1b/0_22_1313_788/master/1313.jpg",
+      "",
+      Dpr.One
+    );
+    expect(src).toContain("quality=85");
+  });
+});

--- a/src/srcsets.ts
+++ b/src/srcsets.ts
@@ -1,0 +1,90 @@
+// ----- Imports ----- //
+
+import { createHash } from "crypto";
+import type { Result } from "@guardian/types";
+import { fromUnsafe, ResultKind } from "@guardian/types";
+
+// ----- Setup ----- //
+
+const imageResizer = "https://i.guim.co.uk/img";
+
+const defaultWidths = [140, 500, 1000, 1500, 2000];
+
+// Percentage.
+const defaultQuality = 85;
+const lowerQuality = 45;
+
+// ----- Types ----- //
+
+const enum Dpr {
+  One,
+  Two,
+}
+
+interface Srcsets {
+  srcset: string;
+  dpr2Srcset: string;
+}
+
+// ----- Functions ----- //
+
+const getSubdomain = (domain: string): string => domain.split(".")[0];
+
+const sign = (salt: string, path: string): string =>
+  createHash("md5")
+    .update(salt + path)
+    .digest("hex");
+
+function src(salt: string, input: string, width: number, dpr: Dpr): string {
+  const maybeUrl: Result<string, URL> = fromUnsafe(
+    () => new URL(input),
+    "invalid url"
+  );
+
+  switch (maybeUrl.kind) {
+    case ResultKind.Ok: {
+      const url = maybeUrl.value;
+      const service = getSubdomain(url.hostname);
+
+      const params = new URLSearchParams({
+        width: width.toString(),
+        quality:
+          dpr === Dpr.Two ? lowerQuality.toString() : defaultQuality.toString(),
+        fit: "bounds",
+      });
+
+      const path = `${url.pathname}?${params.toString()}`;
+      const sig = sign(salt, path);
+
+      return `${imageResizer}/${service}${path}&s=${sig}`;
+    }
+    case ResultKind.Err:
+    default: {
+      return input;
+    }
+  }
+}
+
+const srcsetWithWidths = (widths: number[]) => (
+  url: string,
+  salt: string,
+  dpr: Dpr
+): string =>
+  widths.map((width) => `${src(salt, url, width, dpr)} ${width}w`).join(", ");
+
+const srcset: (
+  url: string,
+  salt: string,
+  dpr: Dpr
+) => string = srcsetWithWidths(defaultWidths);
+
+const srcsets = (url: string, salt: string): Srcsets => ({
+  srcset: srcset(url, salt, Dpr.One),
+  dpr2Srcset: srcset(url, salt, Dpr.Two),
+});
+
+// ----- Exports ----- //
+
+export type { Srcsets };
+
+export { Dpr, src, srcset, srcsets, srcsetWithWidths };


### PR DESCRIPTION
## Why?

Migrating the code used to generate image `src`s and `srcset`s upstream [from AR](https://github.com/guardian/apps-rendering/blob/ea3e7efd11c41d57b20b2086197eba20dffcdaf3/src/image.ts) to Image-Rendering. One of the main benefits of Image-Rendering is having the complex code that generates these values (with their corresponding signature) in one place, where it can be used across multiple editorial platforms (AR, DCR, Editions etc.). We can make decisions about any changes that benefit all platforms in one place, and it may help with caching if we're all using broadly the same image URLs.

At the moment the components don't use this code directly, it's up to the platforms to import it, use it, and pass the result to the components. This gives us the time to manage the migration to Image-Rendering on DCR (@oliverlloyd), and the flexibility to tweak how this code works before going all in across our platforms.

I think this should include a version bump to `4.1.0`.

FYI @paperboyo @philmcmahon 

## Changes

- Added `Dpr` type
- Added `Srcsets` type
- Added functions for generating `src`s and `srcset`s
- Added tests for `srcsets`
- Bumped version to `4.1.0`
