### PR TITLE
Bump To v5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {


### PR DESCRIPTION
## Why?

Some dependency updates to pick up. See the full changes [here](https://github.com/guardian/image-rendering/compare/3490601..269f282).

## Changes

- Bump version to `v5.0.1`
