### PR TITLE
Bump guardian/types To v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2222,18 +2222,8 @@
       "integrity": "sha512-U0XVJWugB6vXoORZPcfvnISAhwaIM5/Pz5uGj628+OcqF3vwm0dBUt1UTesVqOsG7tVUQvGG/n96wXWjGwmVmQ=="
     },
     "@guardian/types": {
-      "version": "github:guardian/types#7c57081d48d517392e4eb7492ece393076fbeaf1",
-      "from": "github:guardian/types#semver:^1.0.0",
-      "requires": {
-        "typescript": "^3.8.3"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "3.9.7",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-          "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
-        }
-      }
+      "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",
+      "from": "github:guardian/types#semver:^1.0.0"
     },
     "@icons/material": {
       "version": "0.2.4",


### PR DESCRIPTION
## Why?

Keeping it up-to-date, but also seeing if this fixes issues we're having in apps-rendering.

## Changes

- Bumped `@guardian/types` to `v1.1.0`
