### PR TITLE
Cache Deps And "npm ci" In Chromatic Workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,8 +9,14 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: '12.16.0'
+            - name: Cache Dependencies
+              uses: actions/cache@v2
+              with:
+                path: ~/.npm
+                key: node-${{ hashFiles('**/package-lock.json') }}
+                restore-keys: node-
             - run: |
-                  npm install && npm run build
+                  npm ci && npm run build
             - uses: chromaui/action@v1
               with:
                   projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
## Why?

Caching dependencies is more efficient and [speeds up execution time](https://github.com/actions/cache). `npm ci` is optimised for installing deps in a CI environment, and can [also be faster](https://docs.npmjs.com/cli/v6/commands/npm-ci) than a regular install.

For an example see the [`nodejs` workflow](https://github.com/guardian/image-rendering/blob/a3119033c610c0b0d8d862e27a778e0466b1d31c/.github/workflows/node.js.yml) in this repo.

## Changes

- Cache the dependencies pulled down by `npm install`
- Use `npm ci` for CI-oriented install
