### PR TITLE
Source v3

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -9,9 +9,7 @@ module.exports = {
                 {
                     loader: require.resolve('babel-loader'),
                     options: {
-                        presets: [
-                            '@emotion/babel-preset-css-prop',
-                        ],
+                        configFile: path.resolve(__dirname, '../config/babel.config.json')
                     }
                 },
                 {

--- a/config/babel.config.json
+++ b/config/babel.config.json
@@ -1,6 +1,12 @@
 {
     "presets": [
-        "@babel/preset-react",
-        "@emotion/babel-preset-css-prop"
-    ]
+        [
+            "@babel/preset-react",
+            {
+                "runtime": "automatic",
+                "importSource": "@emotion/react"
+            }
+        ]
+    ],
+    "plugins": ["@emotion"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2217,9 +2217,9 @@
       "dev": true
     },
     "@guardian/src-foundations": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-2.7.1.tgz",
-      "integrity": "sha512-U0XVJWugB6vXoORZPcfvnISAhwaIM5/Pz5uGj628+OcqF3vwm0dBUt1UTesVqOsG7tVUQvGG/n96wXWjGwmVmQ=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-3.0.1.tgz",
+      "integrity": "sha512-Pu8N4JZYvIaI8cRfW9775j0Q5q2bqstoPg43RQxFTUxkB6jkK3caNwt7WT7eDvlqa4H8uKemTH+rxC0Y4ZWTtw=="
     },
     "@guardian/types": {
       "version": "github:guardian/types#726a50afafba124b1c354f02bff711b24efe5a32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -234,49 +234,6 @@
         "@babel/types": "^7.10.4"
       }
     },
-    "@babel/helper-builder-react-jsx": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-      "integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/types": "^7.10.4"
-      }
-    },
-    "@babel/helper-builder-react-jsx-experimental": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.1.tgz",
-      "integrity": "sha512-82to8lR7TofZWbTd3IEZT1xNHfeU/Ef4rDm/GLXddzqDh+yQ19QuGSzqww51aNxVH8rwfRIzL0EUQsvODVhtyw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-annotate-as-pure": "^7.10.4",
-        "@babel/helper-module-imports": "^7.12.1",
-        "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/helper-module-imports": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
-          "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.12.1"
-          }
-        },
-        "@babel/types": {
-          "version": "7.12.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
-          "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
-      }
-    },
     "@babel/helper-compilation-targets": {
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz",
@@ -561,8 +518,7 @@
     "@babel/helper-plugin-utils": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
-      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
-      "dev": true
+      "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
     },
     "@babel/helper-remap-async-to-generator": {
       "version": "7.12.1",
@@ -1108,7 +1064,6 @@
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz",
       "integrity": "sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==",
-      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
       }
@@ -1469,29 +1424,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.10.4"
-      }
-    },
-    "@babel/plugin-transform-react-jsx": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz",
-      "integrity": "sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-builder-react-jsx": "^7.10.4",
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "^7.12.1"
-      }
-    },
-    "@babel/plugin-transform-react-jsx-development": {
-      "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.1.tgz",
-      "integrity": "sha512-IilcGWdN1yNgEGOrB96jbTplRh+V2Pz1EoEwsKsHfX1a/L40cUYuD71Zepa7C+ujv7kJIxnDftWeZbKNEqZjCQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-builder-react-jsx-experimental": "^7.12.1",
-        "@babel/helper-plugin-utils": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "^7.12.1"
       }
     },
     "@babel/plugin-transform-react-pure-annotations": {
@@ -2020,32 +1952,64 @@
         "minimist": "^1.2.0"
       }
     },
-    "@emotion/babel-plugin-jsx-pragmatic": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.5.tgz",
-      "integrity": "sha512-y+3AJ0SItMDaAgGPVkQBC/S/BaqaPACkQ6MyCI2CUlrjTxKttTVfD3TMtcs7vLEcLxqzZ1xiG0vzwCXjhopawQ==",
-      "dev": true,
+    "@emotion/babel-plugin": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.1.2.tgz",
+      "integrity": "sha512-Nz1k7b11dWw8Nw4Z1R99A9mlB6C6rRsCtZnwNUOj4NsoZdrO2f2A/83ST7htJORD5zpOiLKY59aJN23092949w==",
       "requires": {
-        "@babel/plugin-syntax-jsx": "^7.2.0"
-      }
-    },
-    "@emotion/babel-preset-css-prop": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.2.0.tgz",
-      "integrity": "sha512-3I0CAZ+0fA/VjwNxL4/qfsgiuXtEM/Kvnl49oqSf51bl+kNxsHdypb0J/mdBY8OifuTbwjAOsQkRLVPdUtJN4Q==",
-      "dev": true,
-      "requires": {
-        "@babel/plugin-transform-react-jsx": "^7.12.1",
-        "@babel/plugin-transform-react-jsx-development": "^7.12.1",
-        "@babel/runtime": "^7.5.5",
-        "@emotion/babel-plugin-jsx-pragmatic": "^0.1.5",
-        "babel-plugin-emotion": "^10.0.27"
+        "@babel/helper-module-imports": "^7.7.0",
+        "@babel/plugin-syntax-jsx": "^7.12.1",
+        "@babel/runtime": "^7.7.2",
+        "@emotion/hash": "^0.8.0",
+        "@emotion/memoize": "^0.7.5",
+        "@emotion/serialize": "^1.0.0",
+        "babel-plugin-macros": "^2.6.1",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "^4.0.3"
+      },
+      "dependencies": {
+        "@emotion/memoize": {
+          "version": "0.7.5",
+          "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+          "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+        },
+        "@emotion/serialize": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.0.tgz",
+          "integrity": "sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "csstype": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+        }
       }
     },
     "@emotion/cache": {
       "version": "10.0.29",
       "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
       "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "dev": true,
       "requires": {
         "@emotion/sheet": "0.9.4",
         "@emotion/stylis": "0.8.5",
@@ -2057,6 +2021,7 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
       "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@emotion/cache": "^10.0.27",
@@ -2070,10 +2035,21 @@
       "version": "10.0.27",
       "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
       "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "dev": true,
       "requires": {
         "@emotion/serialize": "^0.11.15",
         "@emotion/utils": "0.11.3",
         "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/css-prettifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@emotion/css-prettifier/-/css-prettifier-1.0.0.tgz",
+      "integrity": "sha512-efxSrRTiTqHTQVKW15Gz5H4pNAw8OqcG8NaiwkJIkqIdNXTD4Qr1zC1Ou6r2acd1oJJ2s56nb1ClnXMiWoj6gQ==",
+      "dev": true,
+      "requires": {
+        "@emotion/memoize": "^0.7.4",
+        "stylis": "^4.0.3"
       }
     },
     "@emotion/hash": {
@@ -2090,15 +2066,135 @@
         "@emotion/memoize": "0.7.4"
       }
     },
+    "@emotion/jest": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@emotion/jest/-/jest-11.1.0.tgz",
+      "integrity": "sha512-nkJY5U/cM3WjFYoKozy4WSKILmV3Y2P/uMynI9HVoCTNuYHSdu0djQBHL6zqBmpRya0sjVT1Sv7lasYYwVoMFg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@emotion/css-prettifier": "^1.0.0",
+        "chalk": "^4.1.0",
+        "specificity": "^0.4.1",
+        "stylis": "^4.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@emotion/memoize": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
+    "@emotion/react": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.1.4.tgz",
+      "integrity": "sha512-9gkhrW8UjV4IGRnEe4/aGPkUxoGS23aD9Vu6JCGfEDyBYL+nGkkRBoMFGAzCT9qFdyUvQp4UUtErbKWxq/JS4A==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "@emotion/cache": "^11.1.3",
+        "@emotion/serialize": "^1.0.0",
+        "@emotion/sheet": "^1.0.1",
+        "@emotion/utils": "^1.0.0",
+        "@emotion/weak-memoize": "^0.2.5",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "dependencies": {
+        "@emotion/cache": {
+          "version": "11.1.3",
+          "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.1.3.tgz",
+          "integrity": "sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/sheet": "^1.0.0",
+            "@emotion/utils": "^1.0.0",
+            "@emotion/weak-memoize": "^0.2.5",
+            "stylis": "^4.0.3"
+          }
+        },
+        "@emotion/serialize": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.0.tgz",
+          "integrity": "sha512-zt1gm4rhdo5Sry8QpCOpopIUIKU+mUSpV9WNmFILUraatm5dttNEaYzUWWSboSMUE6PtN2j1cAsuvcugfdI3mw==",
+          "requires": {
+            "@emotion/hash": "^0.8.0",
+            "@emotion/memoize": "^0.7.4",
+            "@emotion/unitless": "^0.7.5",
+            "@emotion/utils": "^1.0.0",
+            "csstype": "^3.0.2"
+          }
+        },
+        "@emotion/sheet": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.0.1.tgz",
+          "integrity": "sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g=="
+        },
+        "@emotion/utils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+          "integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+        },
+        "csstype": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
+          "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+        }
+      }
+    },
     "@emotion/serialize": {
       "version": "0.11.16",
       "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
       "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "dev": true,
       "requires": {
         "@emotion/hash": "0.8.0",
         "@emotion/memoize": "0.7.4",
@@ -2110,7 +2206,8 @@
     "@emotion/sheet": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+      "dev": true
     },
     "@emotion/styled": {
       "version": "10.0.27",
@@ -2137,7 +2234,8 @@
     "@emotion/stylis": {
       "version": "0.8.5",
       "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+      "dev": true
     },
     "@emotion/unitless": {
       "version": "0.7.5",
@@ -2147,7 +2245,8 @@
     "@emotion/utils": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+      "dev": true
     },
     "@emotion/weak-memoize": {
       "version": "0.2.5",
@@ -5956,6 +6055,7 @@
       "version": "10.0.33",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
       "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@emotion/hash": "0.8.0",
@@ -6118,7 +6218,8 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-plugin-transform-inline-consecutive-adds": {
       "version": "0.4.3",
@@ -7990,26 +8091,6 @@
         "randomfill": "^1.0.3"
       }
     },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
-      }
-    },
     "css-loader": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -8138,7 +8219,8 @@
     "csstype": {
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.13.tgz",
-      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A=="
+      "integrity": "sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==",
+      "dev": true
     },
     "cyclist": {
       "version": "1.0.1",
@@ -11096,7 +11178,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dev": true,
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -12559,26 +12640,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        }
-      }
-    },
-    "jest-emotion": {
-      "version": "10.0.32",
-      "resolved": "https://registry.npmjs.org/jest-emotion/-/jest-emotion-10.0.32.tgz",
-      "integrity": "sha512-hW3IwWc47qRuxnGsWFGY6uIMX8F4YBzq+Qci3LAYUCUqUBNP+1DU1L5Nudo9Ry0NHVFOqDnDeip1p2UR0kVMwA==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.5.5",
-        "@types/jest": "^23.0.2",
-        "chalk": "^2.4.1",
-        "css": "^2.2.1"
-      },
-      "dependencies": {
-        "@types/jest": {
-          "version": "23.3.14",
-          "resolved": "https://registry.npmjs.org/@types/jest/-/jest-23.3.14.tgz",
-          "integrity": "sha512-Q5hTcfdudEL2yOmluA1zaSyPbzWPmJ3XfSWeP3RyoYvS9hnje1ZyagrZOuQ6+1nQC1Gw+7gap3pLNL3xL6UBug==",
-          "dev": true
         }
       }
     },
@@ -16745,6 +16806,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -16975,13 +17037,12 @@
       }
     },
     "react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.1.tgz",
+      "integrity": "sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
+        "object-assign": "^4.1.1"
       }
     },
     "react-color": {
@@ -17358,14 +17419,24 @@
       }
     },
     "react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.1.tgz",
+      "integrity": "sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
+        "scheduler": "^0.20.1"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.20.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+          "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-draggable": {
@@ -17472,6 +17543,16 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==",
       "dev": true
     },
+    "react-shallow-renderer": {
+      "version": "16.14.1",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.14.1.tgz",
+      "integrity": "sha512-rkIMcQi01/+kxiTE9D3fdS959U1g7gs+/rborw++42m1O9FAQiNI/UNRZExVUoAOprn4umcXf+pFRou8i4zuBg==",
+      "dev": true,
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0"
+      }
+    },
     "react-sizeme": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.12.tgz",
@@ -17498,15 +17579,23 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.14.0.tgz",
-      "integrity": "sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-/dRae3mj6aObwkjCcxZPlxDFh73XZLgvwhhyON2haZGUEhiaY5EjfAdw+d/rQmlcFwdTpMXCSGVk374QbCTlrA==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.8.6",
-        "scheduler": "^0.19.1"
+        "react-is": "^17.0.1",
+        "react-shallow-renderer": "^16.13.1",
+        "scheduler": "^0.20.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.1.tgz",
+          "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
+          "dev": true
+        }
       }
     },
     "react-textarea-autosize": {
@@ -18081,9 +18170,10 @@
       }
     },
     "scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -18607,6 +18697,12 @@
       "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw==",
       "dev": true
     },
+    "specificity": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
+      "integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
+      "dev": true
+    },
     "speedometer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
@@ -18994,6 +19090,11 @@
           }
         }
       }
+    },
+    "stylis": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.6.tgz",
+      "integrity": "sha512-1igcUEmYFBEO14uQHAJhCUelTR5jPztfdVKrYxRnDa5D5Dn3w0NxXupJNPr/VV/yRfZYEAco8sTIRZzH3sRYKg=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {
-    "@emotion/core": "^10.1.1",
+    "@emotion/babel-plugin": "^11.1.2",
+    "@emotion/react": "^11.1.4",
     "@guardian/src-foundations": "^3.0.1",
     "@guardian/types": "github:guardian/types#semver:^1.0.0",
-    "react": "^16.14.0",
-    "react-dom": "^16.14.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
     "typescript": "^4.1.3"
   },
   "devDependencies": {
@@ -16,7 +17,7 @@
     "@babel/core": "^7.12.10",
     "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.10",
-    "@emotion/babel-preset-css-prop": "^10.2.0",
+    "@emotion/jest": "^11.1.0",
     "@guardian/eslint-config-typescript": "^0.4.2",
     "@guardian/prettier": "^0.4.2",
     "@storybook/react": "^6.1.0",
@@ -34,9 +35,8 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
-    "jest-emotion": "^10.0.32",
     "prettier": "^2.2.1",
-    "react-test-renderer": "^16.14.0",
+    "react-test-renderer": "^17.0.1",
     "ts-jest": "^26.4.4",
     "ts-loader": "^8.0.14"
   },
@@ -74,7 +74,7 @@
       "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
     ],
     "snapshotSerializers": [
-      "jest-emotion"
+      "@emotion/jest/serializer"
     ],
     "testPathIgnorePatterns": [
       "dist"
@@ -82,6 +82,7 @@
     "globals": {
       "ts-jest": {
         "babelConfig": {
+          "extends": "./config/babel.config.json",
           "presets": [
             [
               "@babel/preset-env",
@@ -90,8 +91,7 @@
                   "node": "10"
                 }
               }
-            ],
-            "@emotion/babel-preset-css-prop"
+            ]
           ]
         }
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "dependencies": {
     "@emotion/core": "^10.1.1",
-    "@guardian/src-foundations": "^2.7.1",
+    "@guardian/src-foundations": "^3.0.1",
     "@guardian/types": "github:guardian/types#semver:^1.0.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",

--- a/src/__snapshots__/sizes.test.tsx.snap
+++ b/src/__snapshots__/sizes.test.tsx.snap
@@ -8,14 +8,14 @@ exports[`styles returns dimensions for each media query 1`] = `
   height: calc(30vw * 0.5);
 }
 
-@media (min-width:980px) {
+@media (min-width: 980px) {
   .emotion-0 {
     width: 20px;
     height: calc(20px * 0.5);
   }
 }
 
-@media (min-width:740px) {
+@media (min-width: 740px) {
   .emotion-0 {
     width: 20%;
     height: calc(20% * 0.5);

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from "@emotion/core";
-import { css } from "@emotion/core";
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
 import { remSpace } from "@guardian/src-foundations";
 import type { Breakpoint } from "@guardian/src-foundations/mq";
 import { from } from "@guardian/src-foundations/mq";

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from "@emotion/core";
-import { css } from "@emotion/core";
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
 import { remSpace } from "@guardian/src-foundations";
 import { neutral, text } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -1,11 +1,10 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from "@emotion/core";
-import { css } from "@emotion/core";
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
 import { neutral } from "@guardian/src-foundations/palette";
 import type { Format, Option } from "@guardian/types";
 import { Design, withDefault } from "@guardian/types";
-import React from "react";
 import type { FC } from "react";
 import type { Image } from "../image";
 import { darkModeCss } from "../lib";

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from "@emotion/core";
-import { css } from "@emotion/core";
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
 
 // ----- Functions ----- //
 

--- a/src/sizes.test.tsx
+++ b/src/sizes.test.tsx
@@ -1,10 +1,7 @@
-/** @jsx jsx */
 // ----- Imports ----- //
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- jest will fail without this
-import { jsx } from "@emotion/core";
+import { matchers } from "@emotion/jest";
 import { breakpoints } from "@guardian/src-foundations/mq";
-import { matchers } from "jest-emotion";
 import renderer from "react-test-renderer";
 import type { Sizes } from "./sizes";
 import { sizesAttribute, styles } from "./sizes";

--- a/src/sizes.ts
+++ b/src/sizes.ts
@@ -1,7 +1,7 @@
 // ----- Imports ----- //
 
-import type { SerializedStyles } from "@emotion/core";
-import { css } from "@emotion/core";
+import type { SerializedStyles } from "@emotion/react";
+import { css } from "@emotion/react";
 import type { Breakpoint } from "@guardian/src-foundations/mq";
 import { breakpoints, from } from "@guardian/src-foundations/mq";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,8 @@
         "allowJs": true,
         // Also emit declaration files
         "declaration": true,
+        // Allows TypeScript to understand the `css` prop from Emotion
+        // https://emotion.sh/docs/typescript#css-prop
+        "jsxImportSource": "@emotion/react",
     }
 }


### PR DESCRIPTION
## Why?

Source v3 [is out](https://github.com/guardian/source/releases/tag/3.0.0)! The biggest changes for this library are the migration to Emotion 11 and React 17, and most of the changes in this PR relate to that - see the list below.

One nice consequence of jumping to newer versions of these libraries is that we can use React's [new JSX transform](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html), which Emotion [can make use of](https://emotion.sh/docs/css-prop#babel-preset). This removes the requirement for the `@jsx` pragmas and the need to disable the linter when importing Emotion's `jsx` the old way. There's just a [small tweak](https://emotion.sh/docs/typescript#css-prop) required for `tsconfig` so that TS understands what's going on.

**Note:** This branches off from #188, which is why dependabot is responsible for the first commit.

## Changes

- Replaced `@emotion/core` with `@emotion/react`
- Replaced `@emotion/babel-preset-css-prop` with `@emotion/babel-plugin`
- Updated React and React-DOM to v17
- Replaced `jest-emotion` with `@emotion/jest`
- Updated `react-test-renderer` to v17
- Updated Babel and TS configs to use React 17's new JSX transform
- Used main Babel config for Jest and Storybook
