### PR TITLE
Add More Image Widths

### DIFF
--- a/src/srcsets.ts
+++ b/src/srcsets.ts
@@ -8,7 +8,7 @@ import { fromUnsafe, ResultKind } from "@guardian/types";
 
 const imageResizer = "https://i.guim.co.uk/img";
 
-const defaultWidths = [140, 500, 1000, 1500, 2000];
+const defaultWidths = [140, 500, 1000, 1500, 2000, 2500, 3000];
 
 // Percentage.
 const defaultQuality = 85;


### PR DESCRIPTION
## Why?

To make images look better on larger/higher-res screens.

## Changes

- Add `2500` and `3000` to list of default image widths
