### PR TITLE
LIVE-1755: update types package to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "5.0.2",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3443,8 +3443,8 @@
       "integrity": "sha512-31V0NYPr+pmu1KOQDgXnvhpoAWc9kzlGgDGyMv8jRi/ihtKJltsVEnto7Cy9zn34kDiFcIuObxE0XpxrucKVAQ=="
     },
     "@guardian/types": {
-      "version": "github:guardian/types#c59efe451b9d0b2931593ff58755c2e99785aad4",
-      "from": "github:guardian/types#semver:^3.0.0"
+      "version": "github:guardian/types#bd66bdfe8358701163053fdeb4efbee2d94a6185",
+      "from": "github:guardian/types#semver:^4.0.0"
     },
     "@icons/material": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@emotion/babel-plugin": "^11.1.2",
     "@emotion/react": "^11.1.4",
     "@guardian/src-foundations": "^3.1.0",
-    "@guardian/types": "github:guardian/types#semver:^3.0.0",
+    "@guardian/types": "github:guardian/types#semver:^4.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "typescript": "^4.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "5.0.2",
+  "version": "5.1.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "5.1.0",
+  "version": "6.0.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
   "dependencies": {

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -20,6 +20,7 @@ const backgroundColour = (format: Format): string => {
     case Design.Media:
       return neutral[20];
     case Design.Comment:
+    case Design.Letter:
       return neutral[86];
     default:
       return neutral[97];


### PR DESCRIPTION
## What does this change?

Updates `@guardian/types` to `4.0.0` so we can do the same on AR. From testing against @dskamiotis AR branch the issues we were having regarding types clashing appear to be resolved by this PR.

## To test

To test with apps rendering install locally in AR project using:

```
npm i "git://github.com/guardian/image-rendering#eca9520e059f76" --save
```

This needs to be done on this branch: https://github.com/guardian/apps-rendering/pull/1176

