### PR TITLE
7.0.0 : Downgrade to @guardian/types v3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "name": "@guardian/image-rendering",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Handles parsing images from CAPI and rendering them in the *-rendering projects",
   "main": "dist/index.js",
-  "dependencies": {
+  "peerDependencies": {
     "@emotion/babel-plugin": "^11.1.2",
     "@emotion/react": "^11.1.5",
     "@guardian/src-foundations": "^3.1.0",
-    "@guardian/types": "github:guardian/types#semver:^4.0.0",
+    "@guardian/types": "^3.0.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "typescript": "^4.1.3"
   },
   "devDependencies": {
+    "@emotion/babel-plugin": "^11.1.2",
+    "@emotion/react": "^11.1.5",
+    "@guardian/src-foundations": "^3.1.0",
+    "@guardian/types": "^3.0.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "typescript": "^4.1.3",
     "@babel/cli": "^7.12.13",
     "@babel/core": "^7.12.13",
     "@babel/preset-env": "^7.12.13",
@@ -39,9 +46,6 @@
     "react-test-renderer": "^17.0.1",
     "ts-jest": "^26.5.3",
     "ts-loader": "^8.0.17"
-  },
-  "peerDependencies": {
-    "@guardian/types": "1.x"
   },
   "scripts": {
     "preinstall": "[ -z \"$CI\" ] || if [[ $npm_execpath =~ 'yarn' ]]; then echo 'Use NPM!' && exit 1; fi",

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -20,7 +20,6 @@ const backgroundColour = (format: Format): string => {
     case Design.Media:
       return neutral[20];
     case Design.Comment:
-    case Design.Letter:
       return neutral[86];
     default:
       return neutral[97];


### PR DESCRIPTION
## What does this change?
Uses all the package updates from v6 (including emotion 11) but downgrades to types `@guardian/types v3`. 

Currently `discussion-rendering` and `atoms-rendering` are still on `@guardian/types v3`, which would result in conflicting versions of types for our `apps-rendering` update for emotion 11. 

This should help us move to emotion 11 on apps-rendering without getting block by discussion-rendering or atoms-rendering for the time being. But it will need to happen soon enough to unblock other work necessary for apps-rendering (for example the Letter template on editions-rendering).
