### PR TITLE
Ignore "tmp" Directory When Linting And Testing

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "extends": "@guardian/eslint-config-typescript",
     "ignorePatterns": [
-        "/dist"
+        "/dist",
+        "/tmp"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
       "@emotion/jest/serializer"
     ],
     "testPathIgnorePatterns": [
-      "dist"
+      "dist",
+      "tmp"
     ],
     "globals": {
       "ts-jest": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,5 +20,6 @@
         // Allows TypeScript to understand the `css` prop from Emotion
         // https://emotion.sh/docs/typescript#css-prop
         "jsxImportSource": "@emotion/react",
-    }
+    },
+    "include": ["src/**/*"],
 }


### PR DESCRIPTION
## Why?

In local development people can sometimes have a `tmp` directory, created as a side-effect of partial runs of the build pipeline. This ignores that directory when running the linter and tests to avoid irrelevant errors being flagged.

## Changes

- Ignored `tmp` in linter config
- Ignored `tmp` in test config
