### PR TITLE
CI Node 14 Instead Of Node 10

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [14.x, 12.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Why?

DCR is now on Node 14, so there's no need to test against Node 10 any more.

## Changes

- Use Node 14 instead of Node 10 for CI
