### PR TITLE
Tweak Caption Styles

### DIFF
--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -3,7 +3,7 @@
 import type { SerializedStyles } from "@emotion/react";
 import { css } from "@emotion/react";
 import { remSpace } from "@guardian/src-foundations";
-import { neutral, text } from "@guardian/src-foundations/palette";
+import { brandAltText, neutral, text } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
 import type { Format, Option } from "@guardian/types";
 import { Design, OptionKind } from "@guardian/types";
@@ -56,22 +56,30 @@ type Props = {
   children: Option<ReactNode>;
 };
 
-const styles = css`
-  ${textSans.xsmall()}
+const styles = (supportsDarkMode: boolean) => css`
+  ${textSans.xxsmall({ lineHeight: 'regular' })}
   padding-top: ${remSpace[2]};
   color: ${text.supporting};
+
+  ${darkModeCss(supportsDarkMode)`
+    color: ${brandAltText.supporting};
+  `}
 `;
 
-const mediaStyles = css`
+const mediaStyles = (supportsDarkMode: boolean) => css`
   color: ${neutral[86]};
+
+  ${darkModeCss(supportsDarkMode)`
+    color: ${neutral[86]};
+  `}
 `;
 
-const getStyles = (format: Format): SerializedStyles => {
+const getStyles = (format: Format, supportsDarkMode: boolean): SerializedStyles => {
   switch (format.design) {
     case Design.Media:
-      return css(styles, mediaStyles);
+      return css(styles(supportsDarkMode), mediaStyles(supportsDarkMode));
     default:
-      return styles;
+      return styles(supportsDarkMode);
   }
 };
 
@@ -83,7 +91,7 @@ export const FigCaption: FC<Props> = ({
   switch (children.kind) {
     case OptionKind.Some:
       return (
-        <figcaption css={getStyles(format)}>
+        <figcaption css={getStyles(format, supportsDarkMode)}>
           <Triangle format={format} supportsDarkMode={supportsDarkMode} />
           {children.value}
         </figcaption>

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -76,7 +76,7 @@ const mediaStyles = (supportsDarkMode: boolean) => css`
 
 const getStyles = (
   format: Format,
-  supportsDarkMode: boolean,
+  supportsDarkMode: boolean
 ): SerializedStyles => {
   switch (format.design) {
     case Design.Media:

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -57,7 +57,7 @@ type Props = {
 };
 
 const styles = (supportsDarkMode: boolean) => css`
-  ${textSans.xxsmall({ lineHeight: 'regular' })}
+  ${textSans.xxsmall({ lineHeight: "regular" })}
   padding-top: ${remSpace[2]};
   color: ${text.supporting};
 
@@ -74,7 +74,10 @@ const mediaStyles = (supportsDarkMode: boolean) => css`
   `}
 `;
 
-const getStyles = (format: Format, supportsDarkMode: boolean): SerializedStyles => {
+const getStyles = (
+  format: Format,
+  supportsDarkMode: boolean,
+): SerializedStyles => {
   switch (format.design) {
     case Design.Media:
       return css(styles(supportsDarkMode), mediaStyles(supportsDarkMode));


### PR DESCRIPTION
## Why?

Applying some tweaks to the image caption styles requested by @benwuersching.

**Note:** Ben, one thing you requested was a `6px` spacing between the caption text and the bottom of the image. However the design system only allows for spacings that are multiples of `4px`, so I've kept it at `8px` for now. If you think this is problematic maybe we should have a chat with Akemi about the rules for spacing?

**Note 2:** The text colour you requested for dark mode was `#999`. Interestingly the only instance of that colour for text in the design system is `brandAltText.supporting`, as seen [here](https://www.theguardian.design/2a1e5182b/p/1377a6-tokens/b/21c6cc/t/11d5fd). I've used that, but it's a weird name for a default theme dark mode colour. We're probably going to have to think about integrating an official dark mode palette into the design system at some point 🤔.

## Changes

- Adjust line height to 'regular' (1.35)
- Reduce font size to 12px
- Change font colour in dark mode
