### PR TITLE
Migrate from `@guardian/types` to `@guardian/libs`

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,10 +1,20 @@
 const path = require('path');
 
+const nodeModulesExclude = [
+    {
+        test: /node_modules/,
+        exclude: [
+            /@guardian\//,
+        ],
+    },
+]
+
 module.exports = {
     stories: ['../src/**/*.stories.tsx'],
     webpackFinal: async config => {
         config.module.rules.push({
             test: /\.(ts|tsx)$/,
+            exclude: nodeModulesExclude,
             use: [
                 {
                     loader: require.resolve('babel-loader'),
@@ -21,6 +31,11 @@ module.exports = {
                 },
             ],
         });
+
+        // update storybook webpack config to transpile *all* JS
+        config.module.rules.find(rule => String(rule.test) === String(/\.(mjs|tsx?|jsx?)$/))
+            .exclude = nodeModulesExclude;
+
         config.resolve.extensions.push('.ts', '.tsx');
         config.resolve.modules.push(path.resolve(__dirname, '../src'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3625,6 +3625,12 @@
         "@guardian/eslint-config": "^0.5.0"
       }
     },
+    "@guardian/libs": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-3.1.0.tgz",
+      "integrity": "sha512-GJk34o9lUmP6FcBKd0FSV2RwvAKKJzcAV5mVdhgq/JmBNj8Ns5eiJlq8LG2ewIJJSzRaWT4h8Fg6n9KI8K0xDQ==",
+      "dev": true
+    },
     "@guardian/prettier": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@guardian/prettier/-/prettier-0.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/jest": "^11.3.0",
     "@guardian/eslint-config-typescript": "^0.5.0",
     "@guardian/prettier": "^0.5.0",
+    "@guardian/libs": "^3.1.0",
     "@storybook/react": "^6.1.0",
     "@types/jest": "^26.0.20",
     "@types/node": "^14.14.31",
@@ -41,7 +42,8 @@
     "ts-loader": "^8.0.17"
   },
   "peerDependencies": {
-    "@guardian/types": "1.x"
+    "@guardian/types": "1.x",
+    "@guardian/libs": "^3.1.0"
   },
   "scripts": {
     "preinstall": "[ -z \"$CI\" ] || if [[ $npm_execpath =~ 'yarn' ]]; then echo 'Use NPM!' && exit 1; fi",
@@ -72,7 +74,7 @@
   "jest": {
     "preset": "ts-jest/presets/js-with-ts",
     "transformIgnorePatterns": [
-      "node_modules/(?!(@guardian/src-foundations|@guardian/types)/)"
+      "node_modules/(?!(@guardian/src-foundations|@guardian/types|@guardian/libs)/)"
     ],
     "snapshotSerializers": [
       "@emotion/jest/serializer"

--- a/src/components/bodyImage.stories.tsx
+++ b/src/components/bodyImage.stories.tsx
@@ -2,7 +2,13 @@
 
 // ----- Imports ----- //
 
-import { Design, Display, none, Pillar, Role, some } from "@guardian/types";
+import {
+  ArticleDesign,
+  ArticleDisplay,
+  ArticleElementRole,
+  ArticlePillar,
+} from "@guardian/libs";
+import { none, some } from "@guardian/types";
 import type { FC } from "react";
 import { image } from "../fixtures/image";
 import { BodyImage } from "./bodyImage";
@@ -10,9 +16,9 @@ import { BodyImage } from "./bodyImage";
 // ----- Setup ----- //
 
 const format = {
-  design: Design.Article,
-  display: Display.Standard,
-  theme: Pillar.News,
+  design: ArticleDesign.Standard,
+  display: ArticleDisplay.Standard,
+  theme: ArticlePillar.News,
 };
 const caption = some(
   "Age of the train … a tourist train in Switzerland. Photograph: Kisa_Markiza/Getty Images"
@@ -65,7 +71,7 @@ const Thumbnail: FC = () => (
     <BodyImage
       image={{
         ...image,
-        role: Role.Thumbnail,
+        role: ArticleElementRole.Thumbnail,
       }}
       format={format}
       supportsDarkMode={true}
@@ -82,7 +88,7 @@ const ThumbnailNoCaption: FC = () => (
     <BodyImage
       image={{
         ...image,
-        role: Role.Thumbnail,
+        role: ArticleElementRole.Thumbnail,
       }}
       format={format}
       supportsDarkMode={true}

--- a/src/components/bodyImage.tsx
+++ b/src/components/bodyImage.tsx
@@ -2,11 +2,13 @@
 
 import type { SerializedStyles } from "@emotion/react";
 import { css } from "@emotion/react";
+import type { ArticleFormat } from "@guardian/libs";
+import { ArticleElementRole } from "@guardian/libs";
 import { remSpace } from "@guardian/src-foundations";
 import type { Breakpoint } from "@guardian/src-foundations/mq";
 import { from } from "@guardian/src-foundations/mq";
-import type { Format, Option } from "@guardian/types";
-import { none, Role, some, withDefault } from "@guardian/types";
+import type { Option } from "@guardian/types";
+import { none, some, withDefault } from "@guardian/types";
 import type { FC, ReactNode } from "react";
 import type { Image } from "../image";
 import { darkModeCss } from "../lib";
@@ -23,9 +25,9 @@ const thumbnailWidth = "8.75rem";
 
 // ----- Functions ----- //
 
-const getSizes = (role: Role): Sizes => {
+const getSizes = (role: ArticleElementRole): Sizes => {
   switch (role) {
-    case Role.Thumbnail:
+    case ArticleElementRole.Thumbnail:
       return {
         mediaQueries: [],
         default: thumbnailWidth,
@@ -42,7 +44,7 @@ const getSizes = (role: Role): Sizes => {
 
 type Props = {
   image: Image;
-  format: Format;
+  format: ArticleFormat;
   supportsDarkMode: boolean;
   lightbox: Option<Lightbox>;
   caption: Option<ReactNode>;
@@ -72,11 +74,11 @@ const thumbnailStyles = (
 `;
 
 const imgStyles = (
-  role: Role,
+  role: ArticleElementRole,
   supportsDarkMode: boolean
 ): Option<SerializedStyles> => {
   switch (role) {
-    case Role.Thumbnail:
+    case ArticleElementRole.Thumbnail:
       return some(css`
         background-color: transparent;
 
@@ -90,11 +92,11 @@ const imgStyles = (
 };
 
 const getStyles = (
-  role: Role,
+  role: ArticleElementRole,
   leftColumnBreakpoint: Option<Breakpoint>
 ): SerializedStyles => {
   switch (role) {
-    case Role.Thumbnail:
+    case ArticleElementRole.Thumbnail:
       return thumbnailStyles(
         withDefault<Breakpoint>("leftCol")(leftColumnBreakpoint)
       );

--- a/src/components/figCaption.stories.tsx
+++ b/src/components/figCaption.stories.tsx
@@ -2,7 +2,8 @@
 
 // ----- Imports ----- //
 
-import { Design, Display, Pillar, some } from "@guardian/types";
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from "@guardian/libs";
+import { some } from "@guardian/types";
 import type { FC } from "react";
 import { FigCaption } from "./figCaption";
 
@@ -11,9 +12,9 @@ import { FigCaption } from "./figCaption";
 const Default: FC = () => (
   <FigCaption
     format={{
-      design: Design.Article,
-      display: Display.Standard,
-      theme: Pillar.News,
+      design: ArticleDesign.Standard,
+      display: ArticleDisplay.Standard,
+      theme: ArticlePillar.News,
     }}
     supportsDarkMode={true}
   >

--- a/src/components/figCaption.tsx
+++ b/src/components/figCaption.tsx
@@ -2,11 +2,13 @@
 
 import type { SerializedStyles } from "@emotion/react";
 import { css } from "@emotion/react";
+import type { ArticleFormat } from "@guardian/libs";
+import { ArticleDesign } from "@guardian/libs";
 import { remSpace } from "@guardian/src-foundations";
 import { brandAltText, neutral, text } from "@guardian/src-foundations/palette";
 import { textSans } from "@guardian/src-foundations/typography";
-import type { Format, Option } from "@guardian/types";
-import { Design, OptionKind } from "@guardian/types";
+import type { Option } from "@guardian/types";
+import { OptionKind } from "@guardian/types";
 import type { FC, ReactNode } from "react";
 import { fill } from "../editorialPalette";
 import { darkModeCss } from "../lib";
@@ -14,12 +16,12 @@ import { darkModeCss } from "../lib";
 // ----- Sub-Components ----- //
 
 interface TriangleProps {
-  format: Format;
+  format: ArticleFormat;
   supportsDarkMode: boolean;
 }
 
 const triangleStyles = (
-  format: Format,
+  format: ArticleFormat,
   supportsDarkMode: boolean
 ): SerializedStyles => css`
   fill: ${fill.iconPrimary(format)};
@@ -33,7 +35,7 @@ const triangleStyles = (
 
 const Triangle: FC<TriangleProps> = ({ format, supportsDarkMode }) => {
   switch (format.design) {
-    case Design.Media:
+    case ArticleDesign.Media:
       return null;
     default:
       return (
@@ -51,7 +53,7 @@ const Triangle: FC<TriangleProps> = ({ format, supportsDarkMode }) => {
 // ----- Component ----- //
 
 type Props = {
-  format: Format;
+  format: ArticleFormat;
   supportsDarkMode: boolean;
   children: Option<ReactNode>;
 };
@@ -75,11 +77,11 @@ const mediaStyles = (supportsDarkMode: boolean) => css`
 `;
 
 const getStyles = (
-  format: Format,
+  format: ArticleFormat,
   supportsDarkMode: boolean
 ): SerializedStyles => {
   switch (format.design) {
-    case Design.Media:
+    case ArticleDesign.Media:
       return css(styles(supportsDarkMode), mediaStyles(supportsDarkMode));
     default:
       return styles(supportsDarkMode);

--- a/src/components/img.stories.tsx
+++ b/src/components/img.stories.tsx
@@ -2,7 +2,8 @@
 
 // ----- Imports ----- //
 
-import { Design, Display, none, Pillar } from "@guardian/types";
+import { ArticleDesign, ArticleDisplay, ArticlePillar } from "@guardian/libs";
+import { none } from "@guardian/types";
 import type { FC } from "react";
 import { image } from "../fixtures/image";
 import { Img } from "./img";
@@ -19,9 +20,9 @@ const Default: FC = () => (
     sizes={sizes}
     className={none}
     format={{
-      design: Design.Article,
-      display: Display.Standard,
-      theme: Pillar.News,
+      design: ArticleDesign.Standard,
+      display: ArticleDisplay.Standard,
+      theme: ArticlePillar.News,
     }}
     supportsDarkMode={true}
     lightbox={none}
@@ -39,9 +40,9 @@ const Placeholder: FC = () => (
     sizes={sizes}
     className={none}
     format={{
-      design: Design.Article,
-      display: Display.Standard,
-      theme: Pillar.News,
+      design: ArticleDesign.Standard,
+      display: ArticleDisplay.Standard,
+      theme: ArticlePillar.News,
     }}
     supportsDarkMode={true}
     lightbox={none}

--- a/src/components/img.tsx
+++ b/src/components/img.tsx
@@ -2,9 +2,11 @@
 
 import type { SerializedStyles } from "@emotion/react";
 import { css } from "@emotion/react";
+import type { ArticleFormat } from "@guardian/libs";
+import { ArticleDesign } from "@guardian/libs";
 import { neutral } from "@guardian/src-foundations/palette";
-import type { Format, Option } from "@guardian/types";
-import { Design, withDefault } from "@guardian/types";
+import type { Option } from "@guardian/types";
+import { withDefault } from "@guardian/types";
 import type { FC } from "react";
 import type { Image } from "../image";
 import { darkModeCss } from "../lib";
@@ -15,12 +17,12 @@ import type { Sizes } from "../sizes";
 
 // ----- Functions ----- //
 
-const backgroundColour = (format: Format): string => {
+const backgroundColour = (format: ArticleFormat): string => {
   switch (format.design) {
-    case Design.Media:
+    case ArticleDesign.Media:
       return neutral[20];
-    case Design.Comment:
-    case Design.Letter:
+    case ArticleDesign.Comment:
+    case ArticleDesign.Letter:
       return neutral[86];
     default:
       return neutral[97];
@@ -33,13 +35,13 @@ type Props = {
   image: Image;
   sizes: Sizes;
   className: Option<SerializedStyles>;
-  format: Format;
+  format: ArticleFormat;
   supportsDarkMode: boolean;
   lightbox: Option<Lightbox>;
 };
 
 const styles = (
-  format: Format,
+  format: ArticleFormat,
   supportsDarkMode: boolean
 ): SerializedStyles => css`
   background-color: ${backgroundColour(format)};

--- a/src/editorialPalette.ts
+++ b/src/editorialPalette.ts
@@ -1,5 +1,7 @@
 // ----- Imports ----- //
 
+import type { ArticleFormat } from "@guardian/libs";
+import { ArticlePillar, ArticleSpecial } from "@guardian/libs";
 import {
   culture,
   lifestyle,
@@ -8,8 +10,6 @@ import {
   specialReport,
   sport,
 } from "@guardian/src-foundations/palette";
-import type { Format } from "@guardian/types";
-import { Pillar, Special } from "@guardian/types";
 
 // ----- Types ----- //
 
@@ -17,37 +17,37 @@ type Colour = string;
 
 // ----- Functions ----- //
 
-const fillIconPrimary = (format: Format): Colour => {
+const fillIconPrimary = (format: ArticleFormat): Colour => {
   switch (format.theme) {
-    case Pillar.Opinion:
+    case ArticlePillar.Opinion:
       return opinion[400];
-    case Pillar.Sport:
+    case ArticlePillar.Sport:
       return sport[400];
-    case Pillar.Culture:
+    case ArticlePillar.Culture:
       return culture[400];
-    case Pillar.Lifestyle:
+    case ArticlePillar.Lifestyle:
       return lifestyle[400];
-    case Special.SpecialReport:
+    case ArticleSpecial.SpecialReport:
       return specialReport[500];
-    case Pillar.News:
+    case ArticlePillar.News:
     default:
       return news[400];
   }
 };
 
-const fillIconPrimaryInverse = (format: Format): Colour => {
+const fillIconPrimaryInverse = (format: ArticleFormat): Colour => {
   switch (format.theme) {
-    case Pillar.Opinion:
+    case ArticlePillar.Opinion:
       return opinion[500];
-    case Pillar.Sport:
+    case ArticlePillar.Sport:
       return sport[500];
-    case Pillar.Culture:
+    case ArticlePillar.Culture:
       return culture[500];
-    case Pillar.Lifestyle:
+    case ArticlePillar.Lifestyle:
       return lifestyle[500];
-    case Special.SpecialReport:
+    case ArticleSpecial.SpecialReport:
       return specialReport[500];
-    case Pillar.News:
+    case ArticlePillar.News:
     default:
       return news[500];
   }

--- a/src/fixtures/image.ts
+++ b/src/fixtures/image.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import { Role, some } from "@guardian/types";
+import { ArticleElementRole } from "@guardian/libs";
+import { some } from "@guardian/types";
 import type { Image } from "../image";
 
 // ----- Fixtures ----- //
@@ -15,7 +16,7 @@ const image: Image = {
   alt: some("Demo image"),
   width: 5644,
   height: 3387,
-  role: Role.Standard,
+  role: ArticleElementRole.Standard,
 };
 
 // ----- Exports ----- //

--- a/src/image.ts
+++ b/src/image.ts
@@ -1,6 +1,7 @@
 // ----- Imports ----- //
 
-import type { Option, Role } from "@guardian/types";
+import type { ArticleElementRole } from "@guardian/libs";
+import type { Option } from "@guardian/types";
 
 // ----- Types ----- //
 
@@ -11,7 +12,7 @@ interface Image {
   alt: Option<string>;
   width: number;
   height: number;
-  role: Role;
+  role: ArticleElementRole;
 }
 
 // ----- Exports ----- //


### PR DESCRIPTION
## What does this change?

This PR migrates from the [`@guardian/types`](https://github.com/guardian/types) library to [`@guardian/libs`](https://github.com/guardian/libs) as [`@guardian/types` is now deprecated](https://github.com/guardian/types/pull/140).

## How to test

Run all validation and ensure that everything still runs as expected.