### PR TITLE
Deprecation/Migration Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # image-rendering
 
+**⚠️ Deprecated ⚠️:** *This functionality has been migrated to the DCR/AR mono-repo: https://github.com/guardian/dotcom-rendering.*
+
 Handles parsing images from CAPI and rendering them in the `*-rendering` projects
 
 ## Components


### PR DESCRIPTION
## Why?

This was migrated to the DCR/AR mono-repo in two PRs:

- https://github.com/guardian/dotcom-rendering/pull/3391
- https://github.com/guardian/dotcom-rendering/pull/3485

AR and DCR are likely to be the only two projects that require this functionality, so there's no need to keep this separate repo going.

## Changes

- Added deprecation warning to README
